### PR TITLE
update "repository" in package.json

### DIFF
--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bucketco/bucket-tracking-sdk.git"
+    "url": "https://github.com/bucketco/bucket-javascript-sdk.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tracking-sdk/package.json
+++ b/packages/tracking-sdk/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bucketco/bucket-tracking-sdk.git"
+    "url": "https://github.com/bucketco/bucket-javascript-sdk.git"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
After we renamed the repository, this is needed for packages to show in GitHub repositories under "Packages".