### PR TITLE
feat: allow multiple attempts to fail before caching a negative result

### DIFF
--- a/packages/tracking-sdk/src/flags-fetch.ts
+++ b/packages/tracking-sdk/src/flags-fetch.ts
@@ -150,11 +150,13 @@ export async function getFlags({
   context,
   staleWhileRevalidate = true,
   timeoutMs = FLAG_FETCH_DEFAULT_TIMEOUT_MS,
+  cacheNegativeAttempts = FAILURE_RETRY_ATTEMPTS,
 }: {
   apiBaseUrl: string;
   context: object;
   staleWhileRevalidate?: boolean;
   timeoutMs?: number;
+  cacheNegativeAttempts?: number | false;
 }): Promise<Flags | undefined> {
   const flattenedContext = flattenJSON({ context });
 
@@ -169,7 +171,9 @@ export async function getFlags({
   // too many times yet - fetch now
   if (
     !cachedItem ||
-    (!cachedItem.success && cachedItem.attemptCount <= FAILURE_RETRY_ATTEMPTS)
+    (!cachedItem.success &&
+      (cacheNegativeAttempts === false ||
+        cachedItem.attemptCount < cacheNegativeAttempts))
   ) {
     return fetchFlags(url, timeoutMs);
   }

--- a/packages/tracking-sdk/test/flags-cache.test.ts
+++ b/packages/tracking-sdk/test/flags-cache.test.ts
@@ -44,11 +44,12 @@ describe("cache", () => {
 
     const flags = { featureA: { value: true, key: "featureA" } };
 
-    cache.set("key", true, flags);
+    cache.set("key", { success: true, flags, attemptCount: 1 });
     expect(cache.get("key")).toEqual({
       stale: false,
       success: true,
       flags,
+      attemptCount: 1,
     } satisfies CacheResult);
   });
 
@@ -57,11 +58,12 @@ describe("cache", () => {
 
     const flags = { featureA: { value: true, key: "featureA" } };
 
-    cache.set("key", false, flags);
+    cache.set("key", { success: false, flags, attemptCount: 1 });
     expect(cache.get("key")).toEqual({
       stale: false,
       success: false,
       flags,
+      attemptCount: 1,
     } satisfies CacheResult);
   });
 
@@ -70,7 +72,7 @@ describe("cache", () => {
 
     const flags = { featureA: { value: true, key: "featureA" } };
 
-    cache.set("key", true, flags);
+    cache.set("key", { success: true, flags, attemptCount: 1 });
 
     vitest.advanceTimersByTime(TEST_STALE_MS + 1);
 
@@ -83,11 +85,11 @@ describe("cache", () => {
 
     const flags = { featureA: { value: true, key: "featureA" } };
 
-    cache.set("first key", true, flags);
+    cache.set("first key", { success: true, flags, attemptCount: 1 });
     expect(cacheItem[0]).not.toBeNull();
     vitest.advanceTimersByTime(TEST_EXPIRE_MS + 1);
 
-    cache.set("other key", true, flags);
+    cache.set("other key", { success: true, flags, attemptCount: 1 });
 
     const item = cache.get("key");
     expect(item).toBeUndefined();


### PR DESCRIPTION
Requests for feature flags get cancelled if there's a page change around the same time as the flag request goes out. There's no reliable way to know if a request was cancelled or otherwise failed.

This PR changes the caching logic so we will not use a negative cached result until it's failed 3 times. If any of the first three requests succeed, that response will be used. 