### PR TITLE
fix: default isLoading to false

### DIFF
--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -28,7 +28,7 @@ const Context = createContext<BucketContext>({
   bucket: BucketSingleton,
   flags: {
     flags: {},
-    isLoading: true,
+    isLoading: false,
   },
 });
 


### PR DESCRIPTION
If the context provider is never initialized, `isLoading` will continue to return true. This fixes that.