### PR TITLE
Remove the async decorator from evaluate (not needed)

### DIFF
--- a/packages/flag-evaluation/package.json
+++ b/packages/flag-evaluation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/flag-evaluation",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -94,10 +94,10 @@ export function unflattenJSON(data: Record<string, any>) {
   return result;
 }
 
-export async function evaluateFlag({
+export function evaluateFlag({
   context,
   flag,
-}: EvaluateFlagParams): Promise<EvaluateFlagResult> {
+}: EvaluateFlagParams): EvaluateFlagResult {
   const flatContext = flattenJSON(context);
 
   const missingContextFieldsSet = new Set<string>();

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -19,7 +19,7 @@ const flag: FlagData = {
 
 describe("evaluate flag integration ", () => {
   it("evaluates flag when there's no matching rule", async () => {
-    const res = await evaluateFlag({
+    const res = evaluateFlag({
       flag,
       context: {
         company: {
@@ -60,7 +60,7 @@ describe("evaluate flag integration ", () => {
         id: "company1",
       },
     };
-    const res = await evaluateFlag({
+    const res = evaluateFlag({
       flag,
       context,
     });
@@ -95,7 +95,7 @@ describe("evaluate flag integration ", () => {
         },
       ],
     };
-    const res = await evaluateFlag({
+    const res = evaluateFlag({
       flag: flagWithSegmentRule,
       context: {
         company: {
@@ -116,7 +116,7 @@ describe("evaluate flag integration ", () => {
   });
 
   it("returns list of missing context keys ", async () => {
-    const res = await evaluateFlag({
+    const res = evaluateFlag({
       flag,
       context: {},
     });
@@ -140,7 +140,7 @@ describe("evaluate flag integration ", () => {
         },
       ],
     };
-    const res = await evaluateFlag({
+    const res = evaluateFlag({
       flag: myflag,
       context: {},
     });
@@ -160,7 +160,7 @@ describe("evaluate flag integration ", () => {
     confusingFlag.rules[0].contextFilter![0].value = "nothing";
     confusingFlag.rules[0].contextFilter![0].values = ["company1"];
 
-    const res = await evaluateFlag({
+    const res = evaluateFlag({
       flag: confusingFlag,
       context: {
         company: {


### PR DESCRIPTION
This PR removes the `async` decorator from evaluating flags as it is unnecessary. This change is required as part of other upcoming PR.