### PR TITLE
Remove the distinction between segment and context filters.

### DIFF
--- a/packages/flag-evaluation/package.json
+++ b/packages/flag-evaluation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/flag-evaluation",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -1,13 +1,9 @@
 import { createHash } from "node:crypto";
 
 export interface Rule {
-  contextFilter?: ContextFilter[];
+  filter?: ContextFilter[];
   partialRolloutThreshold?: number;
   partialRolloutAttribute?: string;
-  segment?: {
-    id: string;
-    attributeFilter: ContextFilter[];
-  };
 }
 
 export type FlagData = {
@@ -48,7 +44,6 @@ type ContextFilterOp =
 export type ContextFilter = {
   field: string;
   operator: ContextFilterOp;
-  value?: string;
   values?: string[];
 };
 
@@ -102,7 +97,7 @@ export function evaluateFlag({
 
   const missingContextFieldsSet = new Set<string>();
   for (const rule of flag.rules) {
-    rule.contextFilter
+    rule.filter
       ?.map((r) => r.field)
       .filter((field) => !(field in flatContext))
       .forEach((field) => missingContextFieldsSet.add(field));
@@ -184,27 +179,14 @@ export function evaluateRuleWithContext({
   context: Record<string, string>;
   rule: Rule;
 }) {
-  // transform segment attribute filter to context filter
-  let contextFilter = rule.contextFilter || [];
-  if (rule.segment) {
-    contextFilter = rule.segment.attributeFilter.map(
-      ({ field, operator, value, values }) => {
-        if (field === "$company_id") {
-          field = "id";
-        }
-        const valuesOut = values?.length ? values : [value || ""];
-        return { field: `company.${field}`, operator, values: valuesOut };
-      },
-    );
-  }
-  const match = contextFilter.every((filter) => {
+  const match = (rule.filter || []).every((filter) => {
     if (!(filter.field in context)) {
       return false;
     }
     return evaluate(
       context[filter.field] as string,
       filter.operator,
-      filter?.values?.length ? filter.values : [filter.value || ""],
+      filter?.values?.length ? filter.values : [""],
     );
   });
 

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -6,11 +6,11 @@ const flag: FlagData = {
     {
       partialRolloutThreshold: 100000,
       partialRolloutAttribute: "company.id",
-      contextFilter: [
+      filter: [
         {
           field: "company.id",
           operator: "IS",
-          value: "company1",
+          values: ["company1"],
         },
       ],
     },
@@ -27,6 +27,7 @@ describe("evaluate flag integration ", () => {
         },
       },
     });
+
     expect(res).toEqual({
       value: false,
       context: {
@@ -38,11 +39,11 @@ describe("evaluate flag integration ", () => {
           {
             partialRolloutThreshold: 100000,
             partialRolloutAttribute: "company.id",
-            contextFilter: [
+            filter: [
               {
                 field: "company.id",
                 operator: "IS",
-                value: "company1",
+                values: ["company1"],
               },
             ],
           },
@@ -76,36 +77,32 @@ describe("evaluate flag integration ", () => {
     });
   });
 
-  it("evaluates flag with segment rule", async () => {
+  it("evaluates flag with missing values", async () => {
     const flagWithSegmentRule: FlagData = {
       key: "flag",
       rules: [
         {
-          segment: {
-            id: "segment1",
-            attributeFilter: [
-              {
-                field: "$company_id",
-                operator: "IS",
-                value: "company1",
-              },
-            ],
-          },
+          filter: [
+            {
+              field: "some_field",
+              operator: "IS",
+            },
+          ],
           partialRolloutThreshold: 100000,
         },
       ],
     };
+
     const res = evaluateFlag({
       flag: flagWithSegmentRule,
       context: {
-        company: {
-          id: "company1",
-        },
+        some_field: "",
       },
     });
+
     expect(res).toEqual({
       context: {
-        "company.id": "company1",
+        some_field: "",
       },
       value: true,
       flag: flagWithSegmentRule,
@@ -151,75 +148,6 @@ describe("evaluate flag integration ", () => {
       reason: "no matched rules",
       missingContextFields: ["happening.id"],
       ruleEvaluationResults: [false],
-    });
-  });
-
-  it("prioritizes values vs value", async () => {
-    const confusingFlag = structuredClone(flag);
-
-    confusingFlag.rules[0].contextFilter![0].value = "nothing";
-    confusingFlag.rules[0].contextFilter![0].values = ["company1"];
-
-    const res = evaluateFlag({
-      flag: confusingFlag,
-      context: {
-        company: {
-          id: "company1",
-        },
-      },
-    });
-
-    expect(res).toEqual({
-      value: true,
-      flag: confusingFlag,
-      context: {
-        "company.id": "company1",
-      },
-      missingContextFields: [],
-      reason: "rule #0 matched",
-      ruleEvaluationResults: [true],
-    });
-  });
-
-  it("also prioritizes values of value for the `$company.id` field", async () => {
-    const companyIdWithAnyOf = {
-      key: "flag",
-      rules: [
-        {
-          partialRolloutThreshold: 100000,
-          partialRolloutAttribute: "company.id",
-          segment: {
-            id: "segment1",
-            attributeFilter: [
-              {
-                field: "$company_id",
-                operator: "ANY_OF" as const,
-                values: ["company1"],
-              },
-            ],
-          },
-        },
-      ],
-    };
-
-    const res = await evaluateFlag({
-      flag: companyIdWithAnyOf,
-      context: {
-        company: {
-          id: "company1",
-        },
-      },
-    });
-
-    expect(res).toEqual({
-      value: true,
-      flag: companyIdWithAnyOf,
-      context: {
-        "company.id": "company1",
-      },
-      missingContextFields: [],
-      reason: "rule #0 matched",
-      ruleEvaluationResults: [true],
     });
   });
 });


### PR DESCRIPTION
This PR removes the distinction between segment and context filters. This is a prerequisite for merging multiple rule types in a flag. 

Other changes will be required in 3 other projects.