### PR TITLE
[React SDK] exclude nextjs example when generating d.ts files

### DIFF
--- a/packages/react-sdk/vite.config.mjs
+++ b/packages/react-sdk/vite.config.mjs
@@ -9,9 +9,9 @@ export default defineConfig({
   optimizeDeps: {
     include: ["@bucketco/browser-sdk"],
   },
-  plugins: [dts({ insertTypesEntry: true })],
+  plugins: [dts({ insertTypesEntry: true, exclude: ["dev"] })],
   build: {
-    exclude: ["**/node_modules/**", "test/e2e/**"],
+    exclude: ["**/node_modules/**", "test/e2e/**", "dev"],
     sourcemap: true,
     lib: {
       entry: resolve(__dirname, "src/index.tsx"),


### PR DESCRIPTION
Although the build process completes successfully, there's a bunch of errors regarding the Next.js example from the d.ts file generation.