### PR TITLE
simplify React SDK

### DIFF
--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -58,11 +58,11 @@ import { BucketProvider } from "@bucketco/react-sdk";
   If you specify `company` and/or `user` they must have at least the `id` property plus anything additional you want to be able to evaluate feature targeting against. See "Managing Bucket context" below.
 
 - `fallbackFeatures` is a list of strings which specify which features to consider enabled if the SDK is unable to fetch features.
-- `loadingComponent` lets you specify an React component to be rendered instead of the children while the Bucket provider is initializing. If you want more control over loading screens, `useFeatures()` returns `isLoading` which you can use to customize the loading experience:
+- `loadingComponent` lets you specify an React component to be rendered instead of the children while the Bucket provider is initializing. If you want more control over loading screens, `useFeature()` returns `isLoading` which you can use to customize the loading experience:
 
   ```tsx
   function LoadingBucket({ children }) {
-    const {isLoading} = useFeatures()
+    const {isLoading} = useFeature("myFeature")
     if (isLoading) {
       return <Spinner />
     }
@@ -79,28 +79,6 @@ import { BucketProvider } from "@bucketco/react-sdk";
   ```
 
 ## Hooks
-
-### `useFeatureIsEnabled()`
-
-Returns a boolean indicating if the given feature is enabled for the current context.
-`useFeatureIsEnabled` returns false while features are being loaded.
-
-Use `useFeature()` for fine-grained control over loading and rendering.
-
-```tsx
-import { useFeatureIsEnabled } from "@bucketco/react-sdk";
-
-function StartHuddleButton() {
-  const joinHuddleFeatureEnabled = useFeatureIsEnabled("huddle");
-  // true / false
-
-  if (!joinHuddleFeatureEnabled) {
-    return null;
-  }
-
-  return <Button />;
-}
-```
 
 ### `useFeature()`
 
@@ -124,54 +102,9 @@ function StartHuddleButton() {
 }
 ```
 
-### `useFeatures()`
-
-Returns all enabled features as an object. Mostly useful for debugging and getting the current loading state.
-
-```tsx
-import { useFeature } from "@bucketco/react-sdk";
-
-function DebugFeatures() {
-  const { isLoading, features } = useFeatures();
-  // {
-  //   "isLoading": false,
-  //   "features: {
-  //     "join-huddle": true
-  //     "post-message": true
-  //   }
-  // }
-
-  if (isLoading) {
-    return <Loading />;
-  }
-
-  return <pre>{JSON.stringify(features)}</pre>;
-}
-```
-
-### `useUpdateContext()`
-
-`useUpdateContext` returns functions `updateCompany`, `updateUser` and `updateOtherContext`. The functions lets you update the _context_ that is used to determine if a feature is enabled or not. For example, if the user logs out, changes company or similar or a specific property changes on the company as in the example below:
-
-```tsx
-import { useUpdateContext } from "@bucketco/react-sdk";
-
-function Company() {
-  const [company, _] = useState(initialCompany);
-  const { updateCompany } = useUpdateContext();
-  return (
-    <div>
-      <button onClick={() => updateCompany({ ...company, plan: "enterprise" })}>
-        Upgrade to enterprise
-      </button>
-    </div>
-  );
-}
-```
-
 ### `useTrack()`
 
-`useTrack()` lets you send events to Bucket. Use this whenever a user _uses_ a feature. Create [features](https://docs.bucket.co/introduction/concepts/feature) in Bucket based off of these events to analyze feature usage.
+`useTrack()` lets you send custom events to Bucket. Use this whenever a user _uses_ a feature. Create [features](https://docs.bucket.co/introduction/concepts/feature) in Bucket based off of these events to analyze feature usage.
 
 ```tsx
 import { useTrack } from "@bucketco/react-sdk";

--- a/packages/react-sdk/dev/nextjs-flag-demo/components/Flags.tsx
+++ b/packages/react-sdk/dev/nextjs-flag-demo/components/Flags.tsx
@@ -1,17 +1,15 @@
 "use client";
 
 import React from "react";
-import { useFeatures } from "@bucketco/react-sdk";
+import { useFeature } from "@bucketco/react-sdk";
 
 export const Features = () => {
-  const features = useFeatures();
+  const { isEnabled } = useFeature("huddle");
   return (
     <div className="border border-gray-300 p-6 rounded-xl dark:border-neutral-800 dark:bg-zinc-800/30">
-      <h3 className="text-xl mb-4">Enabled features:</h3>
+      <h3 className="text-xl mb-4">Huddle feature enabled:</h3>
       <pre>
-        <code className="font-mono font-bold">
-          {JSON.stringify(features, undefined, 2)}
-        </code>
+        <code className="font-mono font-bold">{JSON.stringify(isEnabled)}</code>
       </pre>
     </div>
   );

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -14,17 +14,13 @@ import canonicalJSON from "canonical-json";
 import {
   BucketClient,
   BucketContext,
-  CompanyContext,
   FeaturesOptions,
   Feedback,
   FeedbackOptions,
   RequestFeedbackOptions,
-  UserContext,
 } from "@bucketco/browser-sdk";
 
 import { version } from "../package.json";
-
-type OtherContext = Record<string, any>;
 
 export interface Features {}
 
@@ -41,9 +37,6 @@ type ProviderContextType = {
     features: FeaturesResult;
     isLoading: boolean;
   };
-  updateUser: (user?: UserContext) => void;
-  updateCompany: (company: CompanyContext) => void;
-  updateOtherContext: (otherContext: OtherContext) => void;
 
   sendFeedback: (opts: Omit<Feedback, "userId" | "companyId">) => void;
   requestFeedback: (
@@ -58,9 +51,7 @@ const ProviderContext = createContext<ProviderContextType>({
     features: {},
     isLoading: false,
   },
-  updateUser: () => undefined,
-  updateCompany: () => undefined,
-  updateOtherContext: () => undefined,
+
   track: () => undefined,
   sendFeedback: () => undefined,
   requestFeedback: () => undefined,
@@ -86,9 +77,9 @@ export type BucketProps = BucketContext & {
 
 export function BucketProvider({
   children,
-  user: initialUser,
-  company: initialCompany,
-  otherContext: initialOtherContext,
+  user,
+  company,
+  otherContext,
   publishableKey,
   featureOptions,
   loadingComponent,
@@ -101,13 +92,7 @@ export function BucketProvider({
   const clientRef = useRef<BucketClient>();
   const contextKeyRef = useRef<string>();
 
-  const [featureContext, setFeatureContext] = useState({
-    user: initialUser,
-    company: initialCompany,
-    otherContext: initialOtherContext,
-  });
-  const { user, company } = featureContext;
-
+  const featureContext = { user, company, otherContext };
   const contextKey = canonicalJSON({ config, featureContext });
 
   useEffect(() => {
@@ -166,20 +151,6 @@ export function BucketProvider({
     return () => client.stop();
   }, [contextKey]);
 
-  // call updateUser with no arguments to logout
-  const updateUser = useCallback((newUser?: UserContext) => {
-    setFeatureContext({ ...featureContext, user: newUser });
-  }, []);
-
-  // call updateUser with no arguments to re-set company context
-  const updateCompany = useCallback((newCompany?: CompanyContext) => {
-    setFeatureContext({ ...featureContext, company: newCompany });
-  }, []);
-
-  const updateOtherContext = useCallback((otherContext?: OtherContext) => {
-    setFeatureContext({ ...featureContext, otherContext });
-  }, []);
-
   const track = useCallback(
     (eventName: string, attributes?: Record<string, any>) => {
       if (user?.id === undefined)
@@ -229,9 +200,6 @@ export function BucketProvider({
       features,
       isLoading: featuresLoading,
     },
-    updateUser,
-    updateCompany,
-    updateOtherContext,
     track,
 
     sendFeedback,
@@ -243,21 +211,6 @@ export function BucketProvider({
   }
 
   return <ProviderContext.Provider children={children} value={context} />;
-}
-
-/**
- * Returns true if the feature is enabled.
- * If the provider hasn't finished loading, it will return false.
- *
- * ```ts
- * const isEnabled = useFeatureIsEnabled('huddle');
- * // true / false
- * ```
- */
-export function useFeatureIsEnabled(featureKey: BucketFeatures) {
-  const { features } =
-    useContext<ProviderContextType>(ProviderContext).features;
-  return features[featureKey] ?? false;
 }
 
 /**
@@ -275,63 +228,6 @@ export function useFeature(key: BucketFeatures) {
   const isEnabled = features[key] ?? false;
 
   return { isLoading: isLoading, isEnabled };
-}
-
-/**
- * Returns features as an object, e.g.
- * Note: this returns the raw feature keys, and does not use the
- * optional typing provided through the `Features` type.
- *
- * ```ts
- * const features = useFeatures();
- * // {
- * //   "isLoading": false,
- * //   "features: {
- * //     "huddle": true,
- * //     "post-message": true
- * //   }
- * // }
- * ```
- */
-export function useFeatures(): {
-  isLoading: boolean;
-  features: FeaturesResult;
-} {
-  const { features, isLoading } =
-    useContext<ProviderContextType>(ProviderContext).features;
-
-  return {
-    isLoading,
-    features,
-  };
-}
-
-/**
- * Returns a set of functions to update the current user, company or "other context".
- *
- * ```ts
- *  import { useUpdateContext } from "@bucketco/react-sdk";
- *  function Company() {
- *  const [company, _] = useState(initialCompany);
- *  const { updateCompany } = useUpdateContext();
- *  return (
- *    <div>
- *      <button onClick={() => updateCompany({ ...company, plan: "enterprise" })}>
- *        Upgrade to enterprise
- *      </button>
- *    </div>
- *  );
- * }
- * ```
- */
-export function useUpdateContext() {
-  const {
-    updateUser,
-    updateCompany,
-    updateOtherContext,
-    features: { isLoading },
-  } = useContext<ProviderContextType>(ProviderContext);
-  return { updateUser, updateCompany, updateOtherContext, isLoading };
 }
 
 /**

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -105,11 +105,6 @@ beforeAll(() =>
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-const features = {
-  abc: true,
-  def: true,
-};
-
 beforeAll(() => {
   vi.spyOn(BucketClient.prototype, "initialize");
   vi.spyOn(BucketClient.prototype, "getFeatures");

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -16,14 +16,7 @@ import {
 import { BucketClient } from "@bucketco/browser-sdk";
 import { HttpClient } from "@bucketco/browser-sdk/src/httpClient";
 
-import {
-  BucketProps,
-  BucketProvider,
-  useFeature,
-  useFeatureIsEnabled,
-  useFeatures,
-  useUpdateContext,
-} from "../src";
+import { BucketProps, BucketProvider, useFeature } from "../src";
 
 const originalConsoleError = console.error.bind(console);
 afterEach(() => {
@@ -190,33 +183,6 @@ describe("<BucketProvider />", () => {
   });
 });
 
-describe("useFeatureIsEnabled", () => {
-  test("returns the features in context", async () => {
-    const { result } = renderHook(() => useFeatureIsEnabled("abc"), {
-      wrapper: ({ children }) => getProvider({ children }),
-    });
-
-    await waitFor(() => expect(result.current).toStrictEqual(true));
-    expect(result.current).toStrictEqual(true);
-  });
-});
-
-describe("useFeatures", () => {
-  test("returns a loading state initially, stops loading once initialized", async () => {
-    const { result, unmount } = renderHook(() => useFeatures(), {
-      wrapper: ({ children }) => getProvider({ children }),
-    });
-
-    await waitFor(() =>
-      expect(JSON.stringify(result.current)).toEqual(
-        JSON.stringify({ isLoading: false, features }),
-      ),
-    );
-
-    unmount();
-  });
-});
-
 describe("useFeature", () => {
   test("returns a loading state initially, stops loading once initialized", async () => {
     const { result, unmount } = renderHook(() => useFeature("huddle"), {
@@ -236,105 +202,5 @@ describe("useFeature", () => {
       isLoading: false,
     }),
       unmount();
-  });
-});
-
-describe("useUpdateContext", () => {
-  test("updates SDK when user is reset", async () => {
-    console.error = vi.fn();
-
-    const initialized = vi.mocked(BucketClient.prototype.initialize);
-    const mockedUser = vi.mocked(BucketClient.prototype.user);
-    const mockedStop = vi.mocked(BucketClient.prototype.stop);
-    expect(initialized).not.toHaveBeenCalled();
-    const { result, unmount } = renderHook(() => useUpdateContext(), {
-      wrapper: ({ children }) => getProvider({ children }),
-    });
-
-    expect(initialized).toHaveBeenCalledOnce();
-
-    result.current.updateUser({
-      id: "new-user",
-      name: "new-user-name",
-    });
-
-    await waitFor(() => expect(mockedStop).toHaveBeenCalled());
-    expect(mockedStop).toHaveBeenCalled();
-    expect(mockedUser).toHaveBeenCalledTimes(2);
-    expect(mockedUser).toHaveBeenCalledWith({
-      name: "new-user-name",
-    });
-    expect(initialized).toHaveBeenCalledTimes(2);
-
-    expect(console.error).not.toHaveBeenCalled();
-
-    unmount();
-  });
-
-  test("updates SDK when company is updated", async () => {
-    console.error = vi.fn();
-
-    expect(BucketClient.prototype.initialize).not.toHaveBeenCalled();
-    const { result, unmount } = renderHook(() => useUpdateContext(), {
-      wrapper: ({ children }) => getProvider({ children }),
-    });
-
-    expect(BucketClient.prototype.initialize).toHaveBeenCalledOnce();
-    expect(BucketClient.prototype.stop).not.toHaveBeenCalled();
-    result.current.updateCompany({
-      id: "new-company1",
-      name: "new-company-name",
-    });
-
-    // due to our use of useEffect, stop actually gets called twice
-    await waitFor(() => expect(BucketClient.prototype.stop).toHaveBeenCalled());
-
-    await waitFor(() =>
-      expect(
-        vi.mocked(BucketClient.prototype.initialize),
-      ).toHaveBeenCalledTimes(2),
-    );
-
-    await waitFor(() =>
-      expect(vi.mocked(BucketClient.prototype.company)).toHaveBeenCalledTimes(
-        2,
-      ),
-    );
-    expect(BucketClient.prototype.company).toHaveBeenCalledTimes(2);
-    expect(BucketClient.prototype.company).toHaveBeenCalledWith({
-      name: "new-company-name",
-    });
-    expect(BucketClient.prototype.initialize).toHaveBeenCalledTimes(2);
-
-    expect(console.error).not.toHaveBeenCalled();
-
-    unmount();
-  });
-
-  test("updates SDK when other context is updated", async () => {
-    console.error = vi.fn();
-
-    const initialized = vi.mocked(BucketClient.prototype.initialize);
-    const stop = vi.mocked(BucketClient.prototype.stop);
-    expect(initialized).not.toHaveBeenCalled();
-    const { result, unmount } = renderHook(() => useUpdateContext(), {
-      wrapper: ({ children }) => getProvider({ children }),
-    });
-
-    expect(initialized).toHaveBeenCalledOnce();
-
-    expect(stop).not.toHaveBeenCalled();
-
-    const newOtherContext = { happeningId: "new-conference" };
-    result.current.updateOtherContext(newOtherContext);
-
-    await waitFor(() => expect(stop).toHaveBeenCalled());
-
-    expect(stop).toHaveBeenCalled();
-    expect(console.error).not.toHaveBeenCalled();
-
-    await waitFor(() => result.current.isLoading === false);
-
-    unmount();
   });
 });


### PR DESCRIPTION
To minimize the API we're going to:

- remove `useFeatures`
- remove `useUpdateContext`: Updated example to show how to work around this if really needed

If needed, we can add them back in.
