### PR TITLE
React + Browser v1.1.0

### DIFF
--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/browser-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packageManager": "yarn@4.1.1",
   "license": "MIT",
   "repository": {

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/browser-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "packageManager": "yarn@4.1.1",
   "license": "MIT",
   "repository": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/react-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
   "module": "./dist/bucket-react-sdk.mjs",
   "types": "./dist/types/src/index.d.ts",
   "dependencies": {
-    "@bucketco/browser-sdk": "1.0.0",
+    "@bucketco/browser-sdk": "1.0.1",
     "canonical-json": "^0.0.4"
   },
   "peerDependencies": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/react-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
   "module": "./dist/bucket-react-sdk.mjs",
   "types": "./dist/types/src/index.d.ts",
   "dependencies": {
-    "@bucketco/browser-sdk": "1.0.1",
+    "@bucketco/browser-sdk": "1.1.0",
     "canonical-json": "^0.0.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,7 +1043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bucketco/browser-sdk@npm:1.0.1, @bucketco/browser-sdk@workspace:packages/browser-sdk":
+"@bucketco/browser-sdk@npm:1.1.0, @bucketco/browser-sdk@workspace:packages/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/browser-sdk@workspace:packages/browser-sdk"
   dependencies:
@@ -1136,7 +1136,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bucketco/react-sdk@workspace:packages/react-sdk"
   dependencies:
-    "@bucketco/browser-sdk": "npm:1.0.1"
+    "@bucketco/browser-sdk": "npm:1.1.0"
     "@bucketco/eslint-config": "workspace:^"
     "@bucketco/tsconfig": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,7 +1043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bucketco/browser-sdk@npm:1.0.0, @bucketco/browser-sdk@workspace:packages/browser-sdk":
+"@bucketco/browser-sdk@npm:1.0.1, @bucketco/browser-sdk@workspace:packages/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/browser-sdk@workspace:packages/browser-sdk"
   dependencies:
@@ -1136,7 +1136,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bucketco/react-sdk@workspace:packages/react-sdk"
   dependencies:
-    "@bucketco/browser-sdk": "npm:1.0.0"
+    "@bucketco/browser-sdk": "npm:1.0.1"
     "@bucketco/eslint-config": "workspace:^"
     "@bucketco/tsconfig": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"


### PR DESCRIPTION
After https://github.com/bucketco/bucket-javascript-sdk/pull/176 goes in, we'll cut this new version.