### PR TITLE
otherContext is just `other` for the API

### DIFF
--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -106,7 +106,12 @@ export class BucketClient {
 
     this.featuresClient = new FeaturesClient(
       this.httpClient,
-      this.context,
+      // API expects `other` and we have `otherContext`.
+      {
+        user: this.context.user,
+        company: this.context.company,
+        other: this.context.otherContext,
+      },
       this.logger,
       opts?.features,
     );

--- a/packages/browser-sdk/src/feature/features.ts
+++ b/packages/browser-sdk/src/feature/features.ts
@@ -1,5 +1,4 @@
 import { FEATURE_EVENTS_PER_MIN } from "../config";
-import { BucketContext } from "../context";
 import { HttpClient } from "../httpClient";
 import { Logger, loggerWithPrefix } from "../logger";
 import RateLimiter from "../rateLimiter";
@@ -118,7 +117,11 @@ export class FeaturesClient {
 
   constructor(
     private httpClient: HttpClient,
-    private context: BucketContext,
+    private context: {
+      user?: Record<string, any>;
+      company?: Record<string, any>;
+      other?: Record<string, any>;
+    },
     logger: Logger,
     options?: FeaturesOptions & {
       cache?: FeatureCache;

--- a/packages/browser-sdk/test/features.test.ts
+++ b/packages/browser-sdk/test/features.test.ts
@@ -59,7 +59,7 @@ describe("FeaturesClient unit tests", () => {
 
     expect(httpClient.get).toBeCalledTimes(1);
     const calls = vi.mocked(httpClient.get).mock.calls.at(0);
-    const { params, path, timeoutMs } = calls?.[0]!;
+    const { params, path, timeoutMs } = calls![0];
 
     const paramsObj = Object.fromEntries(new URLSearchParams(params));
     expect(paramsObj).toEqual({


### PR DESCRIPTION
I kept the BucketClient API to be `otherContext`. It's a lot clearer than `other` especially since we're merging the "context" into the regular options here #189.