### PR TITLE
chore(NodeSDK): expose Context

### DIFF
--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -2,9 +2,9 @@ export { BoundBucketClient, BucketClient } from "./client";
 export type {
   Attributes,
   ClientOptions,
+  Context,
   Features,
   HttpClient,
   Logger,
   TrackingMeta,
-  Context,
 } from "./types";

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -6,4 +6,5 @@ export type {
   HttpClient,
   Logger,
   TrackingMeta,
+  Context,
 } from "./types";


### PR DESCRIPTION
Useful for any downstream libraries wrapping the NodeSDK.