### PR TITLE
fix(NodeSDK): getFeatures() should return all features

### DIFF
--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -477,19 +477,17 @@ export class BucketClient {
         });
       });
 
-      evaluatedFeatures = evaluated
-        .filter((e) => e.value)
-        .reduce(
-          (acc, res) => {
-            acc[res.feature.key as keyof TypedFeatures] = {
-              key: res.feature.key,
-              isEnabled: res.value,
-              targetingVersion: keyToVersionMap.get(res.feature.key),
-            };
-            return acc;
-          },
-          {} as Record<keyof TypedFeatures, InternalFeature>,
-        );
+      evaluatedFeatures = evaluated.reduce(
+        (acc, res) => {
+          acc[res.feature.key as keyof TypedFeatures] = {
+            key: res.feature.key,
+            isEnabled: res.value,
+            targetingVersion: keyToVersionMap.get(res.feature.key),
+          };
+          return acc;
+        },
+        {} as Record<keyof TypedFeatures, InternalFeature>,
+      );
 
       this._config.logger?.debug("evaluated features", evaluatedFeatures);
     } else {

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -780,10 +780,15 @@ describe("BucketClient", () => {
           isEnabled: true,
           track: expect.any(Function),
         },
+        feature2: {
+          key: "feature2",
+          isEnabled: false,
+          track: expect.any(Function),
+        },
       });
 
       expect(evaluateTargeting).toHaveBeenCalledTimes(2);
-      expect(httpClient.post).toHaveBeenCalledTimes(3); // For "evaluate" events
+      expect(httpClient.post).toHaveBeenCalledTimes(4); // For "evaluate" events
 
       expect(httpClient.post).toHaveBeenNthCalledWith(
         1,
@@ -856,11 +861,16 @@ describe("BucketClient", () => {
           key: "feature1",
           track: expect.any(Function),
         },
+        feature2: {
+          key: "feature2",
+          isEnabled: false,
+          track: expect.any(Function),
+        },
       });
       await flushPromises();
 
       expect(evaluateTargeting).toHaveBeenCalledTimes(2);
-      expect(httpClient.post).toHaveBeenCalledTimes(3); // For 2x "evaluate", 1x "check" events
+      expect(httpClient.post).toHaveBeenCalledTimes(4); // For 3x "evaluate", 1x "check" events
 
       expect(httpClient.post).toHaveBeenNthCalledWith(
         1,
@@ -906,12 +916,17 @@ describe("BucketClient", () => {
           key: "feature1",
           track: expect.any(Function),
         },
+        feature2: {
+          key: "feature2",
+          isEnabled: false,
+          track: expect.any(Function),
+        },
       });
 
       await flushPromises();
 
       expect(evaluateTargeting).toHaveBeenCalledTimes(2);
-      expect(httpClient.post).toHaveBeenCalledTimes(3); // For 2x "evaluate", 1x "check" events
+      expect(httpClient.post).toHaveBeenCalledTimes(4); // For 3x "evaluate", 1x "check" events
 
       expect(httpClient.post).toHaveBeenNthCalledWith(
         1,
@@ -1043,6 +1058,11 @@ describe("BucketClient", () => {
         feature1: {
           key: "feature1",
           isEnabled: true,
+          track: expect.any(Function),
+        },
+        feature2: {
+          key: "feature2",
+          isEnabled: false,
           track: expect.any(Function),
         },
       });


### PR DESCRIPTION
`getFeatures()` was only returning enabled features which caused situations where user code would throw an error in case the feature was disabled.

This would fail because the expression on the right would be `undefined`
```ts
const {track, isEnabled} = client.getFeatures(context)["huddle"]
```