### PR TITLE
feat: `enableTracking` makes it possible to disable tracking

### DIFF
--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -80,6 +80,8 @@ Supply these to the constructor call (3rd argument)
   host?: "https://front.bucket.co",
   sseHost?: "https://livemessaging.bucket.co"
   feedback?: undefined // See FEEDBACK.md
+  trackUser?: true, // automatically notify Bucket servers of user details
+  trackCompany?: true, // automatically notify Bucket servers of company details and connect user with company
   featureOptions?: {
     fallbackFeatures?: string[]; // Enable these features if unable to contact bucket.co
     timeoutMs?: number; // Timeout for fetching features

--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -80,8 +80,7 @@ Supply these to the constructor call (3rd argument)
   host?: "https://front.bucket.co",
   sseHost?: "https://livemessaging.bucket.co"
   feedback?: undefined // See FEEDBACK.md
-  trackUser?: true, // automatically notify Bucket servers of user details
-  trackCompany?: true, // automatically notify Bucket servers of company details and connect user with company
+  trackContext?: true, // by default, user/company details are sent to Bucket for use in the UI. Disable when impersonating.
   featureOptions?: {
     fallbackFeatures?: string[]; // Enable these features if unable to contact bucket.co
     timeoutMs?: number; // Timeout for fetching features

--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -80,7 +80,7 @@ Supply these to the constructor call (3rd argument)
   host?: "https://front.bucket.co",
   sseHost?: "https://livemessaging.bucket.co"
   feedback?: undefined // See FEEDBACK.md
-  impersonating?: false, // disables sending track events and user/company updates to Bucket servers and disables automated feedback surveys.
+  impersonating?: false, // set to `true` to stop sending track events and user/company updates to Bucket servers. Also stops automated feedback surveys.
   featureOptions?: {
     fallbackFeatures?: string[]; // Enable these features if unable to contact bucket.co
     timeoutMs?: number; // Timeout for fetching features

--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -80,7 +80,7 @@ Supply these to the constructor call (3rd argument)
   host?: "https://front.bucket.co",
   sseHost?: "https://livemessaging.bucket.co"
   feedback?: undefined // See FEEDBACK.md
-  enableTracking?: true, // set to `false` to stop sending track events and user/company updates to Bucket servers.
+  enableTracking?: true, // set to `false` to stop sending track events and user/company updates to Bucket servers. Useful when you're impersonating a user.
   featureOptions?: {
     fallbackFeatures?: string[]; // Enable these features if unable to contact bucket.co
     timeoutMs?: number; // Timeout for fetching features

--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -80,7 +80,7 @@ Supply these to the constructor call (3rd argument)
   host?: "https://front.bucket.co",
   sseHost?: "https://livemessaging.bucket.co"
   feedback?: undefined // See FEEDBACK.md
-  impersonating?: false, // set to `true` to stop sending track events and user/company updates to Bucket servers. Also stops automated feedback surveys.
+  enableTracking?: true, // set to `false` to stop sending track events and user/company updates to Bucket servers.
   featureOptions?: {
     fallbackFeatures?: string[]; // Enable these features if unable to contact bucket.co
     timeoutMs?: number; // Timeout for fetching features

--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -80,7 +80,7 @@ Supply these to the constructor call (3rd argument)
   host?: "https://front.bucket.co",
   sseHost?: "https://livemessaging.bucket.co"
   feedback?: undefined // See FEEDBACK.md
-  trackContext?: true, // by default, user/company details are sent to Bucket for use in the UI. Disable when impersonating.
+  impersonating?: false, // disables sending track events and user/company updates to Bucket servers and disables automated feedback surveys.
   featureOptions?: {
     fallbackFeatures?: string[]; // Enable these features if unable to contact bucket.co
     timeoutMs?: number; // Timeout for fetching features

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -250,9 +250,7 @@ export class BucketClient {
       return;
     }
     if (this.config.impersonating) {
-      this.logger.debug(
-        "'track' call ignored. Tracking is disabled by configuration",
-      );
+      this.logger.debug("'track' call ignored. 'impersonating' is enabled");
       return;
     }
 

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -246,11 +246,11 @@ export class BucketClient {
    */
   async track(eventName: string, attributes?: Record<string, any> | null) {
     if (!this.context.user) {
-      this.logger.debug("'track' call ignored. No user context provided");
+      this.logger.warn("'track' call ignored. No user context provided");
       return;
     }
     if (this.config.impersonating) {
-      this.logger.debug("'track' call ignored. 'impersonating' is enabled");
+      this.logger.warn("'track' call ignored. 'impersonating' is enabled");
       return;
     }
 

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -138,8 +138,8 @@ export class BucketClient {
     if (
       this.context?.user &&
       !isNode && // do not prompt on server-side
-      feedbackOpts?.enableAutoFeedback !== false && // default to on)
-      !this.config.impersonating // do not prompt if tracking is disabled
+      feedbackOpts?.enableAutoFeedback !== false && // default to on
+      !this.config.impersonating // do not prompt if impersonating
     ) {
       if (isMobile) {
         this.logger.warn(

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -55,6 +55,8 @@ export type PayloadContext = {
 interface Config {
   host: string;
   sseHost: string;
+  trackUser: boolean;
+  trackCompany: boolean;
 }
 
 export interface InitOptions {
@@ -68,11 +70,15 @@ export interface InitOptions {
   feedback?: FeedbackOptions;
   features?: FeaturesOptions;
   sdkVersion?: string;
+  trackUser?: boolean;
+  trackCompany?: boolean;
 }
 
 const defaultConfig: Config = {
   host: API_HOST,
   sseHost: SSE_REALTIME_HOST,
+  trackUser: true,
+  trackCompany: true,
 };
 
 export interface Feature {
@@ -105,6 +111,8 @@ export class BucketClient {
     this.config = {
       host: opts?.host ?? defaultConfig.host,
       sseHost: opts?.sseHost ?? defaultConfig.sseHost,
+      trackUser: opts?.trackUser ?? defaultConfig.trackUser,
+      trackCompany: opts?.trackCompany ?? defaultConfig.trackCompany,
     } satisfies Config;
 
     const feedbackOpts = handleDeprecatedFeedbackOptions(opts?.feedback);
@@ -169,13 +177,13 @@ export class BucketClient {
 
     await this.featuresClient.initialize();
 
-    if (this.context.user) {
+    if (this.context.user && this.config.trackUser) {
       this.user().catch((e) => {
         this.logger.error("error sending user", e);
       });
     }
 
-    if (this.context.company) {
+    if (this.context.company && this.config.trackCompany) {
       this.company().catch((e) => {
         this.logger.error("error sending company", e);
       });

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -55,8 +55,7 @@ export type PayloadContext = {
 interface Config {
   host: string;
   sseHost: string;
-  trackUser: boolean;
-  trackCompany: boolean;
+  trackContext: boolean;
 }
 
 export interface InitOptions {
@@ -70,15 +69,13 @@ export interface InitOptions {
   feedback?: FeedbackOptions;
   features?: FeaturesOptions;
   sdkVersion?: string;
-  trackUser?: boolean;
-  trackCompany?: boolean;
+  trackContext?: boolean;
 }
 
 const defaultConfig: Config = {
   host: API_HOST,
   sseHost: SSE_REALTIME_HOST,
-  trackUser: true,
-  trackCompany: true,
+  trackContext: true,
 };
 
 export interface Feature {
@@ -111,8 +108,7 @@ export class BucketClient {
     this.config = {
       host: opts?.host ?? defaultConfig.host,
       sseHost: opts?.sseHost ?? defaultConfig.sseHost,
-      trackUser: opts?.trackUser ?? defaultConfig.trackUser,
-      trackCompany: opts?.trackCompany ?? defaultConfig.trackCompany,
+      trackContext: opts?.trackContext ?? defaultConfig.trackContext,
     } satisfies Config;
 
     const feedbackOpts = handleDeprecatedFeedbackOptions(opts?.feedback);
@@ -177,13 +173,13 @@ export class BucketClient {
 
     await this.featuresClient.initialize();
 
-    if (this.context.user && this.config.trackUser) {
+    if (this.context.user && this.config.trackContext) {
       this.user().catch((e) => {
         this.logger.error("error sending user", e);
       });
     }
 
-    if (this.context.company && this.config.trackCompany) {
+    if (this.context.company && this.config.trackContext) {
       this.company().catch((e) => {
         this.logger.error("error sending company", e);
       });

--- a/packages/browser-sdk/test/init.test.ts
+++ b/packages/browser-sdk/test/init.test.ts
@@ -1,5 +1,5 @@
 import { DefaultBodyType, http, StrictRequest } from "msw";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi, vitest } from "vitest";
 
 import { BucketClient } from "../src";
 
@@ -53,5 +53,37 @@ describe("init", () => {
     await bucketInstance.initialize();
 
     expect(usedSpecialHost).toBe(true);
+  });
+
+  test("automatically does user/company tracking", async () => {
+    const user = vitest.spyOn(BucketClient.prototype as any, "user");
+    const company = vitest.spyOn(BucketClient.prototype as any, "company");
+
+    const bucketInstance = new BucketClient({
+      publishableKey: KEY,
+      user: { id: "foo" },
+      company: { id: "bar" },
+    });
+    await bucketInstance.initialize();
+
+    expect(user).toHaveBeenCalled();
+    expect(company).toHaveBeenCalled();
+  });
+
+  test("can disable user/company tracking", async () => {
+    const user = vitest.spyOn(BucketClient.prototype as any, "user");
+    const company = vitest.spyOn(BucketClient.prototype as any, "company");
+
+    const bucketInstance = new BucketClient({
+      publishableKey: KEY,
+      user: { id: "foo" },
+      host: "https://example.com",
+      trackCompany: false,
+      trackUser: false,
+    });
+    await bucketInstance.initialize();
+
+    expect(user).not.toHaveBeenCalled();
+    expect(company).not.toHaveBeenCalled();
   });
 });

--- a/packages/browser-sdk/test/init.test.ts
+++ b/packages/browser-sdk/test/init.test.ts
@@ -78,8 +78,7 @@ describe("init", () => {
       publishableKey: KEY,
       user: { id: "foo" },
       host: "https://example.com",
-      trackCompany: false,
-      trackUser: false,
+      trackContext: false,
     });
     await bucketInstance.initialize();
 

--- a/packages/browser-sdk/test/init.test.ts
+++ b/packages/browser-sdk/test/init.test.ts
@@ -71,7 +71,7 @@ describe("init", () => {
     expect(company).toHaveBeenCalled();
   });
 
-  test("can disable tracking", async () => {
+  test("impersonate disables tracking and auto. feedback surveys", async () => {
     const post = vitest.spyOn(HttpClient.prototype as any, "post");
 
     const bucketInstance = new BucketClient({

--- a/packages/browser-sdk/test/init.test.ts
+++ b/packages/browser-sdk/test/init.test.ts
@@ -2,6 +2,7 @@ import { DefaultBodyType, http, StrictRequest } from "msw";
 import { beforeEach, describe, expect, test, vi, vitest } from "vitest";
 
 import { BucketClient } from "../src";
+import { HttpClient } from "../src/httpClient";
 
 import { getFeatures } from "./mocks/handlers";
 import { server } from "./mocks/server";
@@ -70,19 +71,18 @@ describe("init", () => {
     expect(company).toHaveBeenCalled();
   });
 
-  test("can disable user/company tracking", async () => {
-    const user = vitest.spyOn(BucketClient.prototype as any, "user");
-    const company = vitest.spyOn(BucketClient.prototype as any, "company");
+  test("can disable tracking", async () => {
+    const post = vitest.spyOn(HttpClient.prototype as any, "post");
 
     const bucketInstance = new BucketClient({
       publishableKey: KEY,
       user: { id: "foo" },
       host: "https://example.com",
-      trackContext: false,
+      impersonating: true,
     });
     await bucketInstance.initialize();
+    await bucketInstance.track("test");
 
-    expect(user).not.toHaveBeenCalled();
-    expect(company).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
   });
 });

--- a/packages/browser-sdk/test/init.test.ts
+++ b/packages/browser-sdk/test/init.test.ts
@@ -71,14 +71,17 @@ describe("init", () => {
     expect(company).toHaveBeenCalled();
   });
 
-  test("impersonate disables tracking and auto. feedback surveys", async () => {
+  test("can disable tracking and auto. feedback surveys", async () => {
     const post = vitest.spyOn(HttpClient.prototype as any, "post");
 
     const bucketInstance = new BucketClient({
       publishableKey: KEY,
       user: { id: "foo" },
       host: "https://example.com",
-      impersonating: true,
+      enableTracking: false,
+      feedback: {
+        enableAutoFeedback: false,
+      },
     });
     await bucketInstance.initialize();
     await bucketInstance.track("test");

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -80,7 +80,7 @@ import { BucketProvider } from "@bucketco/react-sdk";
   <BucketProvider>
   ```
 
-- `impersonating` (default: `false`): Set to `true` to stop sending tracking events and user/company updates to Bucket. Also stops automated feedback surveys.
+- `enableTracking` (default: `true`): Set to `false` to stop sending tracking events and user/company updates to Bucket.
 
 ## Hooks
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -80,7 +80,7 @@ import { BucketProvider } from "@bucketco/react-sdk";
   <BucketProvider>
   ```
 
-- `impersonating` (default: `false`): Disables sending tracking events and user/company updates to Bucket and disabled automated feedback surveys. Set to `true` when impersonating another user.
+- `impersonating` (default: `false`): Set to `true` to stop sending tracking events and user/company updates to Bucket. Also stops automated feedback surveys.
 
 ## Hooks
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -80,7 +80,7 @@ import { BucketProvider } from "@bucketco/react-sdk";
   <BucketProvider>
   ```
 
-- `trackContext` (default: `true`): Automatically send user/company details to Bucket. Disable when impersonating another user.
+- `impersonating` (default: `false`): Disables sending tracking events and user/company updates to Bucket and disabled automated feedback surveys. Set to `true` when impersonating another user.
 
 ## Hooks
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -80,7 +80,7 @@ import { BucketProvider } from "@bucketco/react-sdk";
   <BucketProvider>
   ```
 
-- `enableTracking` (default: `true`): Set to `false` to stop sending tracking events and user/company updates to Bucket.
+- `enableTracking` (default: `true`): Set to `false` to stop sending tracking events and user/company updates to Bucket. Useful when you're impersonating a user.
 
 ## Hooks
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -80,6 +80,9 @@ import { BucketProvider } from "@bucketco/react-sdk";
   <BucketProvider>
   ```
 
+- `trackUser` (default: `true`): Automatically send user details to Bucket.
+- `trackCompany` (default: `true`): Automatically send company details to Bucket and connect user with company.
+
 ## Hooks
 
 ### `useFeature()`

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -80,8 +80,7 @@ import { BucketProvider } from "@bucketco/react-sdk";
   <BucketProvider>
   ```
 
-- `trackUser` (default: `true`): Automatically send user details to Bucket.
-- `trackCompany` (default: `true`): Automatically send company details to Bucket and connect user with company.
+- `trackContext` (default: `true`): Automatically send user/company details to Bucket. Disable when impersonating another user.
 
 ## Hooks
 

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -56,7 +56,7 @@ export type BucketProps = BucketContext & {
   host?: string;
   sseHost?: string;
   debug?: boolean;
-  impersonating?: boolean;
+  enableTracking?: boolean;
 
   // for testing
   newBucketClient?: (
@@ -105,7 +105,7 @@ export function BucketProvider({
       host: config.host,
       sseHost: config.sseHost,
 
-      impersonating: config.impersonating,
+      enableTracking: config.enableTracking,
 
       features: {
         ...featureOptions,

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -56,9 +56,7 @@ export type BucketProps = BucketContext & {
   host?: string;
   sseHost?: string;
   debug?: boolean;
-
-  trackUser?: boolean;
-  trackCompany?: boolean;
+  trackContext?: boolean;
 
   // for testing
   newBucketClient?: (
@@ -107,8 +105,7 @@ export function BucketProvider({
       host: config.host,
       sseHost: config.sseHost,
 
-      trackUser: config.trackUser,
-      trackCompany: config.trackCompany
+      trackContext: config.trackContext,
 
       features: {
         ...featureOptions,

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -57,6 +57,9 @@ export type BucketProps = BucketContext & {
   sseHost?: string;
   debug?: boolean;
 
+  trackUser?: boolean;
+  trackCompany?: boolean;
+
   // for testing
   newBucketClient?: (
     ...args: ConstructorParameters<typeof BucketClient>
@@ -103,6 +106,10 @@ export function BucketProvider({
       otherContext,
       host: config.host,
       sseHost: config.sseHost,
+
+      trackUser: config.trackUser,
+      trackCompany: config.trackCompany
+
       features: {
         ...featureOptions,
       },

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -56,7 +56,7 @@ export type BucketProps = BucketContext & {
   host?: string;
   sseHost?: string;
   debug?: boolean;
-  trackContext?: boolean;
+  impersonating?: boolean;
 
   // for testing
   newBucketClient?: (
@@ -105,7 +105,7 @@ export function BucketProvider({
       host: config.host,
       sseHost: config.sseHost,
 
-      trackContext: config.trackContext,
+      impersonating: config.impersonating,
 
       features: {
         ...featureOptions,

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -159,7 +159,7 @@ describe("<BucketProvider />", () => {
       company: { id: "123", name: "test" },
       user: { id: "456", name: "test" },
       otherContext: { test: "test" },
-      impersonating: true,
+      enableTracking: false,
       newBucketClient,
     });
 
@@ -182,7 +182,7 @@ describe("<BucketProvider />", () => {
         host: "https://test.com",
         logger: undefined,
         sseHost: "https://test.com",
-        impersonating: true,
+        enableTracking: false,
         feedback: undefined,
         features: {},
         sdkVersion: `react-sdk/${version}`,

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -159,7 +159,7 @@ describe("<BucketProvider />", () => {
       company: { id: "123", name: "test" },
       user: { id: "456", name: "test" },
       otherContext: { test: "test" },
-      trackContext: false,
+      impersonating: true,
       newBucketClient,
     });
 
@@ -182,7 +182,7 @@ describe("<BucketProvider />", () => {
         host: "https://test.com",
         logger: undefined,
         sseHost: "https://test.com",
-        trackContext: false,
+        impersonating: true,
         feedback: undefined,
         features: {},
         sdkVersion: `react-sdk/${version}`,

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -159,6 +159,7 @@ describe("<BucketProvider />", () => {
       company: { id: "123", name: "test" },
       user: { id: "456", name: "test" },
       otherContext: { test: "test" },
+      trackContext: false,
       newBucketClient,
     });
 
@@ -181,6 +182,7 @@ describe("<BucketProvider />", () => {
         host: "https://test.com",
         logger: undefined,
         sseHost: "https://test.com",
+        trackContext: false,
         feedback: undefined,
         features: {},
         sdkVersion: `react-sdk/${version}`,


### PR DESCRIPTION
In situations where you do not want to send events or track user/company details on behalf of a user but still want to use them for feature targeting, you should be able to disable it. This is useful for example when and admin is impersonating another user.

