### PR TITLE
feat(browser-sdk): use feature key and deprecate feature ID

### DIFF
--- a/packages/browser-sdk/FEEDBACK.md
+++ b/packages/browser-sdk/FEEDBACK.md
@@ -1,12 +1,15 @@
 # Bucket Feedback UI
 
-The Bucket Browser SDK includes a UI you can use to collect feedback from user about particular features.
+The Bucket Browser SDK includes a UI you can use to collect feedback from user
+about particular features.
 
 ![image](https://github.com/bucketco/bucket-javascript-sdk/assets/34348/c387bac1-f2e2-4efd-9dda-5030d76f9532)
 
 ## Global feedback configuration
 
-The Bucket Browser SDK feedback UI is configured with reasonable defaults, positioning itself as a [dialog](#dialog) in the lower right-hand corner of the viewport, displayed in english, and with a [light-mode theme](#custom-styling).
+The Bucket Browser SDK feedback UI is configured with reasonable defaults,
+positioning itself as a [dialog](#dialog) in the lower right-hand corner of
+the viewport, displayed in English, and with a [light-mode theme](#custom-styling).
 
 These settings can be overwritten when initializing the Bucket Browser SDK:
 
@@ -37,16 +40,24 @@ const bucket = new BucketClient({
 See also:
 
 - [Positioning and behavior](#positioning-and-behavior) for the position option.
-- [Static language configuration](#static-language-configuration) if you want to translate the feedback UI.
-- [Automated Feedback Surveys](#automated-feedback-surveys) to override default configuration.
+- [Static language configuration](#static-language-configuration) if you want to
+  translate the feedback UI.
+- [Automated feedback surveys](#automated-feedback-surveys) to
+  override default configuration.
 
-## Automated Feedback Surveys
+## Automated feedback surveys
 
 Automated feedback surveys are enabled by default.
 
-When automated feedback surveys are enabled, the Bucket Browser SDK will open and maintain a connection to the Bucket service. When a user triggers an event tracked by a feature and is eligible to be prompted for feedback, the Bucket service will send a request to the SDK instance. By default, this request will open up the Bucket feedback UI in the user's browser, but you can intercept the request and override this behavior.
+When automated feedback surveys are enabled, the Bucket Browser SDK
+will open and maintain a connection to the Bucket service. When a user
+triggers an event tracked by a feature and is eligible to be prompted
+for feedback, the Bucket service will send a request to the SDK instance.
+By default, this request will open up the Bucket feedback UI in the user's
+browser, but you can intercept the request and override this behavior.
 
-The live connection for automated feedback is established when the `BucketClient` is initialized.
+The live connection for automated feedback is established when the
+`BucketClient` is initialized.
 
 ### Disabling Automated Feedback Surveys
 
@@ -64,7 +75,9 @@ const bucket = new BucketClient({
 
 ### Overriding prompt event defaults
 
-If you are not satisfied with the default UI behavior when an automated prompt event arrives, you can can [override the global defaults](#global-feedback-configuration) or intercept and override settings at runtime like this:
+If you are not satisfied with the default UI behavior when an automated prompt
+event arrives, you can can [override the global defaults](#global-feedback-configuration)
+or intercept and override settings at runtime like this:
 
 ```javascript
 const bucket = new BucketClient({
@@ -96,14 +109,22 @@ const bucket = new BucketClient({
 See also:
 
 - [Positioning and behavior](#positioning-and-behavior) for the position option.
-- [Runtime language configuration](#runtime-language-configuration) if you want to translate the feedback UI.
-- [Use your own UI to collect feedback](#using-your-own-ui-to-collect-feedback) if the feedback UI doesn't match your design.
+- [Runtime language configuration](#runtime-language-configuration) if you want
+  to translate the feedback UI.
+- [Use your own UI to collect feedback](#using-your-own-ui-to-collect-feedback) if
+  the feedback UI doesn't match your design.
 
 ## Manual feedback collection
 
-To open up the feedback collection UI, call `bucketClient.requestFeedback(options)` with the appropriate options. This approach is particularly beneficial if you wish to retain manual control over feedback collection from your users while leveraging the convenience of the Bucket feedback UI to reduce the amount of code you need to maintain.
+To open up the feedback collection UI, call `bucketClient.requestFeedback(options)`
+with the appropriate options. This approach is particularly beneficial if you wish
+to retain manual control over feedback collection from your users while leveraging
+the convenience of the Bucket feedback UI to reduce the amount of code you need
+to maintain.
 
-Examples of this could be if you want the click of a `give us feedback`-button or the end of a specific user flow, to trigger a pop-up displaying the feedback user interface.
+Examples of this could be if you want the click of a `give us feedback`-button
+or the end of a specific user flow, to trigger a pop-up displaying the feedback
+user interface.
 
 ### bucketClient.requestFeedback() options
 
@@ -111,7 +132,7 @@ Minimal usage with defaults:
 
 ```javascript
 bucketClient.requestFeedback({
-  featureId: "bucket-feature-id",
+  featureKey: "bucket-feature-key",
   title: "How satisfied are you with file uploads?",
 });
 ```
@@ -120,8 +141,9 @@ All options:
 
 ```javascript
 bucketClient.requestFeedback({
-  featureId: "bucket-feature-id", // [Required]
-  userId: "your-user-id",  // [Optional] if user persistence is enabled (default in browsers),
+  featureKey: "bucket-feature-key", // [Required]
+  userId: "your-user-id",  // [Optional] if user persistence is
+                           // enabled (default in browsers),
   companyId: "users-company-or-account-id", // [Optional]
   title: "How satisfied are you with file uploads?" // [Optional]
 
@@ -142,7 +164,8 @@ bucketClient.requestFeedback({
 See also:
 
 - [Positioning and behavior](#positioning-and-behavior) for the position option.
-- [Runtime language configuration](#runtime-language-configuration) if you want to translate the feedback UI.
+- [Runtime language configuration](#runtime-language-configuration) if
+  you want to translate the feedback UI.
 
 ## Positioning and behavior
 
@@ -152,11 +175,17 @@ The feedback UI can be configured to be placed and behave in 3 different ways:
 
 #### Modal
 
-A modal overlay with a backdrop that blocks interaction with the underlying page. It can be dismissed with the keyboard shortcut `<ESC>` or the dedicated close button in the top right corner. It is always centered on the page, capturing focus, and making it the primary interface the user needs to interact with.
+A modal overlay with a backdrop that blocks interaction with the underlying
+page. It can be dismissed with the keyboard shortcut `<ESC>` or the dedicated
+close button in the top right corner. It is always centered on the page, capturing
+focus, and making it the primary interface the user needs to interact with.
 
 ![image](https://github.com/bucketco/bucket-tracking-sdk/assets/331790/6c6efbd3-cf7d-4d5b-b126-7ac978b2e512)
 
-Using a modal is the strongest possible push for feedback. You are interrupting the user's normal flow, which can cause annoyance. A good use-case for the modal is when the user finishes a linear flow that they don't perform often, for example setting up a new account.
+Using a modal is the strongest possible push for feedback. You are interrupting the
+user's normal flow, which can cause annoyance. A good use-case for the modal is
+when the user finishes a linear flow that they don't perform often, for example
+setting up a new account.
 
 ```javascript
 position: {
@@ -166,18 +195,27 @@ position: {
 
 #### Dialog
 
-A dialog that appears in a specified corner of the viewport, without limiting the user's interaction with the rest of the page. It can be dismissed with the dedicated close button, but will automatically disappear after a short time period if the user does not interact with it.
+A dialog that appears in a specified corner of the viewport, without limiting the
+user's interaction with the rest of the page. It can be dismissed with the dedicated
+close button, but will automatically disappear after a short time period if the user
+does not interact with it.
 
 ![image](https://github.com/bucketco/bucket-tracking-sdk/assets/331790/30413513-fd5f-4a2c-852a-9b074fa4666c)
 
-Using a dialog is a soft push for feedback. It lets the user continue their work with a minimal amount of intrusion. The user can opt-in to respond but is not required to. A good use case for this behavior is when a user uses a feature where the expected outcome is predictable, possibly because they have used it multiple times before. For example: Uploading a file, switching to a different view of a visualization, visiting a specific page, or manipulating some data.
+Using a dialog is a soft push for feedback. It lets the user continue their work
+with a minimal amount of intrusion. The user can opt-in to respond but is not
+required to. A good use case for this behavior is when a user uses a feature where
+the expected outcome is predictable, possibly because they have used it multiple
+times before. For example: Uploading a file, switching to a different view of a
+visualization, visiting a specific page, or manipulating some data.
 
-The default feedback UI behavior is a dialog placed in the bottom right corner of the viewport.
+The default feedback UI behavior is a dialog placed in the bottom right corner of
+the viewport.
 
 ```typescript
 position: {
-  type: "DIALOG",
-  placement: "top-left" | "top-right" | "bottom-left" | "bottom-right"
+  type: "DIALOG";
+  placement: "top-left" | "top-right" | "bottom-left" | "bottom-right";
   offset?: {
     x?: string | number; // e.g. "-5rem", "10px" or 10 (pixels)
     y?: string | number;
@@ -187,17 +225,18 @@ position: {
 
 #### Popover
 
-A popover that is anchored relative to a DOM-element (typically a button). It can be dismissed by clicking outside the popover or by pressing the dedicated close button.
+A popover that is anchored relative to a DOM-element (typically a button). It can
+be dismissed by clicking outside the popover or by pressing the dedicated close button.
 
 ![image](https://github.com/bucketco/bucket-tracking-sdk/assets/331790/4c5c5597-9ed3-4d4d-90c0-950926d0d967)
 
 You can use the popover mode to implement your own button to collect feedback manually.
 
-```javascript
-position: {
-  type: "POPOVER",
-  anchor: DOMElement
-}
+```typescript
+type Position = {
+  type: "POPOVER";
+  anchor: DOMElement;
+};
 ```
 
 Popover feedback button example:
@@ -208,7 +247,7 @@ Popover feedback button example:
   const button = document.getElementById("feedbackButton");
   button.addEventListener("click", (e) => {
     bucketClient.requestFeedback({
-      featureId: "bucket-feature-id",
+      featureKey: "bucket-feature-key",
       userId: "your-user-id",
       title: "How do you like the popover?",
       position: {
@@ -222,17 +261,23 @@ Popover feedback button example:
 
 ## Internationalization (i18n)
 
-By default, the feedback UI is written in English. However, you can supply your own translations by passing an object in the options to either or both of the `new BucketClient(options)` or `bucketClient.requestFeedback(options)` calls. These translations will replace the English ones used by the feedback interface. See examples below.
+By default, the feedback UI is written in English. However, you can supply your own
+translations by passing an object in the options to either or both of the
+`new BucketClient(options)` or `bucketClient.requestFeedback(options)` calls.
+These translations will replace the English ones used by the feedback interface.
+See examples below.
 
 ![image](https://github.com/bucketco/bucket-tracking-sdk/assets/331790/68805b38-e9f6-4de5-9f55-188216983e3c)
 
-See [default english localization keys](./src/feedback/config/defaultTranslations.tsx) for a reference of what translation keys can be supplied.
+See [default English localization keys](./src/feedback/config/defaultTranslations.tsx)
+for a reference of what translation keys can be supplied.
 
 ### Static language configuration
 
-If you know the language at page load, you can configure your translation keys while initializing the Bucket Browser SDK:
+If you know the language at page load, you can configure your translation keys while
+initializing the Bucket Browser SDK:
 
-```javascript
+```typescript
 new BucketClient({
   publishableKey: "my-publishable-key",
   feedback: {
@@ -260,11 +305,12 @@ new BucketClient({
 
 ### Runtime language configuration
 
-If you only know the user's language after the page has loaded, you can provide translations to either the `bucketClient.requestFeedback(options)` call or the `autoFeedbackHandler` option before the feedback interface opens. See examples below.
+If you only know the user's language after the page has loaded, you can provide
+translations to either the `bucketClient.requestFeedback(options)` call or
+the `autoFeedbackHandler` option before the feedback interface opens.
+See examples below.
 
-### Manual feedback collection
-
-```javascript
+```typescript
 bucketClient.requestFeedback({
   ... // Other options
   translations: {
@@ -273,11 +319,14 @@ bucketClient.requestFeedback({
 })
 ```
 
-### Automated Feedback Surveys
+### Automated feedback surveys i18n
 
-When you are collecting feedback through the Bucket automation, you can intercept the default prompt handling and override the defaults.
+When you are collecting feedback through the Bucket automation, you can intercept
+the default prompt handling and override the defaults.
 
-If you set the prompt question in the Bucket app to be one of your own translation keys, you can even get a translated version of the question you want to ask your customer in the feedback UI.
+If you set the prompt question in the Bucket app to be one of your own translation
+keys, you can even get a translated version of the question you want to ask your
+customer in the feedback UI.
 
 ```javascript
 new BucketClient({
@@ -299,11 +348,18 @@ new BucketClient({
 
 ## Custom styling
 
-You can adapt parts of the look of the Bucket feedback UI by applying CSS custom properties to your page in your CSS `:root`-scope.
+You can adapt parts of the look of the Bucket feedback UI by applying CSS custom
+properties to your page in your CSS `:root`-scope.
 
 For example, a dark mode theme might look like this:
 
-<img width="276" alt="image" src="https://github.com/bucketco/bucket-tracking-sdk/assets/34348/5d579b7b-a830-4530-8b40-864488a8597e">
+```html
+<img
+  width="276"
+  alt="image"
+  src="https://github.com/bucketco/bucket-tracking-sdk/assets/34348/5d579b7b-a830-4530-8b40-864488a8597e"
+/>
+```
 
 ```css
 :root {
@@ -333,48 +389,53 @@ For example, a dark mode theme might look like this:
 }
 ```
 
-Other examples of custom styling can be found in our [development example stylesheet](./dev/index.css).
+Other examples of custom styling can be found in our [development example style-sheet](./dev/index.css).
 
 ## Using your own UI to collect feedback
 
-You may have very strict design guidelines for your app and maybe the Bucket feedback UI doesn't quite work for you.
-
-In this case, you can implement your own feedback collection mechanism, which follows your own design guidelines.
-
-This is the data type you need to collect:
+You may have very strict design guidelines for your app and maybe the Bucket feedback
+UI doesn't quite work for you. In this case, you can implement your own feedback
+collection mechanism, which follows your own design guidelines. This is the data
+type you need to collect:
 
 ```typescript
-{
-  /** Customer satisfaction score */
-  score?: 1 | 2 | 3 | 4 | 5,
-  comment?: string
-}
+type DataToCollect = {
+  // Customer satisfaction score
+  score?: 1 | 2 | 3 | 4 | 5;
+
+  // The comment.
+  comment?: string;
+};
 ```
 
-Either `score` or `comment` must be defined in order to pass validation in the Bucket API.
+Either `score` or `comment` must be defined in order to pass validation in the
+Bucket API.
 
-### Manual feedback collection
+### Manual feedback collection with custom UI
 
-Examples of a HTML-form that collects the relevant data can be found in [feedback.html](./example/feedback/feedback.html) and [feedback.jsx](./example/feedback/feedback.jsx).
+Examples of a HTML-form that collects the relevant data can be found
+in [feedback.html](./example/feedback/feedback.html) and [feedback.jsx](./example/feedback/feedback.jsx).
 
 Once you have collected the feedback data, pass it along to `bucketClient.feedback()`:
 
 ```javascript
 bucketClient.feedback({
-  featureId: "bucket-feature-id",
+  featureKey: "bucket-feature-key",
   userId: "your-user-id",
   score: 5,
-  comment: "Best thing I"ve ever tried!",
+  comment: "Best thing I've ever tried!",
 });
 ```
 
 ### Intercepting automated feedback survey events
 
-When using automated feedback surveys, the Bucket service will, when specified, send a feedback prompt message to your user's instance of the Bucket Browser SDK. This will result in the feedback UI being opened.
+When using automated feedback surveys, the Bucket service will, when specified,
+send a feedback prompt message to your user's instance of the Bucket Browser SDK.
+This will result in the feedback UI being opened.
 
 You can intercept this behavior and open your own custom feedback collection form:
 
-```javascript
+```typescript
 new Bucketclient({
   publishableKey: "bucket-publishable-key",
   feedback: {

--- a/packages/browser-sdk/test/mocks/handlers.ts
+++ b/packages/browser-sdk/test/mocks/handlers.ts
@@ -93,7 +93,12 @@ export const handlers = [
   http.post("https://front.bucket.co/feedback", async ({ request }) => {
     if (!checkRequest(request)) return invalidReqResponse;
     const data = await request.json();
-    if (!data || !data["userId"] || typeof data["score"] !== "number") {
+    if (
+      !data ||
+      !data["userId"] ||
+      typeof data["score"] !== "number" ||
+      (!data["featureId"] && !data["featureKey"])
+    ) {
       return new HttpResponse(null, { status: 400 });
     }
 

--- a/packages/browser-sdk/test/usage.test.ts
+++ b/packages/browser-sdk/test/usage.test.ts
@@ -53,7 +53,7 @@ describe("usage", () => {
     vi.clearAllMocks();
   });
 
-  test("golden path - register user, company, send event, send feedback, get features", async () => {
+  test("golden path - register `user`, `company`, send `event`, send `feedback`, get `features`", async () => {
     const bucketInstance = new BucketClient({
       publishableKey: KEY,
       user: { id: "foo " },
@@ -73,6 +73,23 @@ describe("usage", () => {
 
     const features = bucketInstance.getFeatures();
     expect(features).toEqual(featuresResult);
+  });
+
+  test("accepts `featureKey` instead of `featureId` for manual feedback", async () => {
+    const bucketInstance = new BucketClient({
+      publishableKey: KEY,
+      user: { id: "foo" },
+      company: { id: "bar" },
+    });
+
+    await bucketInstance.initialize();
+
+    await bucketInstance.feedback({
+      featureKey: "feature-key",
+      score: 5,
+      question: "What's up?",
+      promptedQuestion: "How are you?",
+    });
   });
 });
 
@@ -356,7 +373,8 @@ describe(`sends "check" events `, () => {
     ).toHaveBeenCalledTimes(0);
 
     const featureA = client.getFeatures()?.featureA;
-    expect(featureA.isEnabled).toBe(true);
+
+    expect(featureA?.isEnabled).toBe(true);
     expect(
       vi.mocked(FeaturesClient.prototype.sendCheckEvent),
     ).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
For [manual] feedback, add `featureKey` and mark `featureId` as deprecated.