### PR TITLE
fix: offline: ensure batchBuffer is not added to and no logging happens

### DIFF
--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -374,9 +374,6 @@ export class BucketClient {
         this._config.staleWarningInterval,
         this._config.logger,
         async () => {
-          if (this._config.offline) {
-            return { features: [] };
-          }
           const res = await this.get<FeaturesAPIResponse>("features");
 
           if (!isObject(res) || !Array.isArray(res?.features)) {

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -594,66 +594,74 @@ export class BucketClient {
   }
 
   private _getFeatures(context: Context): Record<string, RawFeature> {
-    const featureDefinitions = this.getFeaturesCache().get();
     let evaluatedFeatures: Record<keyof TypedFeatures, RawFeature> =
       this._config.fallbackFeatures || {};
 
-    if (featureDefinitions) {
-      const keyToVersionMap = new Map<string, number>(
-        featureDefinitions.features.map((f) => [f.key, f.targeting.version]),
-      );
-
-      const evaluated = featureDefinitions.features.map((feature) =>
-        evaluateTargeting({ context, feature }),
-      );
-
-      evaluated.forEach(async (res) => {
-        this.sendFeatureEvent({
-          action: "evaluate",
-          key: res.feature.key,
-          targetingVersion: keyToVersionMap.get(res.feature.key),
-          evalResult: res.value,
-          evalContext: res.context,
-          evalRuleResults: res.ruleEvaluationResults,
-          evalMissingFields: res.missingContextFields,
-        }).catch((err) => {
-          this._config.logger?.error(
-            `failed to send evaluate event for "${res.feature.key}"`,
-            err,
-          );
-        });
-      });
-
-      evaluatedFeatures = evaluated.reduce(
-        (acc, res) => {
-          acc[res.feature.key as keyof TypedFeatures] = {
-            key: res.feature.key,
-            isEnabled: res.value,
-            targetingVersion: keyToVersionMap.get(res.feature.key),
-          };
-          return acc;
-        },
-        {} as Record<keyof TypedFeatures, RawFeature>,
-      );
-
-      // apply feature overrides
-      const overrides = Object.entries(
-        this._config.featureOverrides(context),
-      ).map(([key, isEnabled]) => [key, { key, isEnabled }]);
-
-      if (overrides.length > 0) {
-        // merge overrides into evaluated features
-        evaluatedFeatures = {
-          ...evaluatedFeatures,
-          ...Object.fromEntries(overrides),
-        };
-      }
-      this._config.logger?.debug("evaluated features", evaluatedFeatures);
+    let featureDefinitions: FeaturesAPIResponse["features"];
+    if (this._config.offline) {
+      featureDefinitions = [];
     } else {
-      this._config.logger?.warn(
-        "failed to use feature definitions, there are none cached yet. Using fallback features.",
-      );
+      const fetchedFeatures = this.getFeaturesCache().get();
+      if (!fetchedFeatures) {
+        this._config.logger?.warn(
+          "failed to use feature definitions, there are none cached yet. Using fallback features.",
+        );
+        return this._config.fallbackFeatures || {};
+      }
+      featureDefinitions = fetchedFeatures.features;
     }
+
+    const keyToVersionMap = new Map<string, number>(
+      featureDefinitions.map((f) => [f.key, f.targeting.version]),
+    );
+
+    const evaluated = featureDefinitions.map((feature) =>
+      evaluateTargeting({ context, feature }),
+    );
+
+    evaluated.forEach(async (res) => {
+      this.sendFeatureEvent({
+        action: "evaluate",
+        key: res.feature.key,
+        targetingVersion: keyToVersionMap.get(res.feature.key),
+        evalResult: res.value,
+        evalContext: res.context,
+        evalRuleResults: res.ruleEvaluationResults,
+        evalMissingFields: res.missingContextFields,
+      }).catch((err) => {
+        this._config.logger?.error(
+          `failed to send evaluate event for "${res.feature.key}"`,
+          err,
+        );
+      });
+    });
+
+    evaluatedFeatures = evaluated.reduce(
+      (acc, res) => {
+        acc[res.feature.key as keyof TypedFeatures] = {
+          key: res.feature.key,
+          isEnabled: res.value,
+          targetingVersion: keyToVersionMap.get(res.feature.key),
+        };
+        return acc;
+      },
+      {} as Record<keyof TypedFeatures, RawFeature>,
+    );
+
+    // apply feature overrides
+    const overrides = Object.entries(
+      this._config.featureOverrides(context),
+    ).map(([key, isEnabled]) => [key, { key, isEnabled }]);
+
+    if (overrides.length > 0) {
+      // merge overrides into evaluated features
+      evaluatedFeatures = {
+        ...evaluatedFeatures,
+        ...Object.fromEntries(overrides),
+      };
+    }
+    this._config.logger?.debug("evaluated features", evaluatedFeatures);
+
     return evaluatedFeatures;
   }
 

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -283,10 +283,6 @@ export class BucketClient {
       "events must be a non-empty array",
     );
 
-    if (this._config.offline) {
-      return;
-    }
-
     const sent = await this.post("bulk", events);
     if (!sent) {
       throw new Error("Failed to send bulk events");
@@ -347,6 +343,10 @@ export class BucketClient {
       flattenJSON(event.evalContext || {}),
     ).toString();
 
+    if (this._config.offline) {
+      return;
+    }
+
     if (
       !this._config.rateLimiter.isAllowed(
         `${event.action}:${contextKey}:${event.key}:${event.targetingVersion}:${event.evalResult}`,
@@ -375,7 +375,6 @@ export class BucketClient {
         this._config.logger,
         async () => {
           if (this._config.offline) {
-            console.log("offline");
             return { features: [] };
           }
           const res = await this.get<FeaturesAPIResponse>("features");
@@ -462,6 +461,10 @@ export class BucketClient {
       "meta must be an object",
     );
 
+    if (this._config.offline) {
+      return;
+    }
+
     await this._config.batchBuffer.add({
       type: "user",
       userId,
@@ -502,6 +505,10 @@ export class BucketClient {
       opts?.userId === undefined || typeof opts.userId === "string",
       "userId must be a string",
     );
+
+    if (this._config.offline) {
+      return;
+    }
 
     await this._config.batchBuffer.add({
       type: "company",
@@ -548,6 +555,10 @@ export class BucketClient {
       opts?.companyId === undefined || typeof opts.companyId === "string",
       "companyId must be an string",
     );
+
+    if (this._config.offline) {
+      return;
+    }
 
     await this._config.batchBuffer.add({
       type: "event",

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -576,7 +576,9 @@ export class BucketClient {
    * Call this method before calling `getFeatures` to ensure the feature definitions are cached.
    **/
   public async initialize() {
-    await this.getFeaturesCache().refresh();
+    if (!this._config.offline) {
+      await this.getFeaturesCache().refresh();
+    }
   }
 
   /**
@@ -591,9 +593,6 @@ export class BucketClient {
   }
 
   private _getFeatures(context: Context): Record<string, RawFeature> {
-    let evaluatedFeatures: Record<keyof TypedFeatures, RawFeature> =
-      this._config.fallbackFeatures || {};
-
     let featureDefinitions: FeaturesAPIResponse["features"];
     if (this._config.offline) {
       featureDefinitions = [];
@@ -633,7 +632,7 @@ export class BucketClient {
       });
     });
 
-    evaluatedFeatures = evaluated.reduce(
+    let evaluatedFeatures = evaluated.reduce(
       (acc, res) => {
         acc[res.feature.key as keyof TypedFeatures] = {
           key: res.feature.key,

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -1635,20 +1635,18 @@ describe("BucketClient", () => {
     let client: BucketClient;
 
     beforeEach(async () => {
-      client = new BucketClient({ offline: true });
-      // no need to initialize in `offline` mode
+      client = new BucketClient({
+        ...validOptions,
+        offline: true,
+      });
+      client.initialize();
     });
 
-    it("should send not send, fetch or log anything", async () => {
+    it("should send not send or fetch anything", async () => {
       client.getFeatures({});
 
       expect(httpClient.get).toHaveBeenCalledTimes(0);
       expect(httpClient.post).toHaveBeenCalledTimes(0);
-
-      expect(logger.debug).toHaveBeenCalledTimes(0);
-      expect(logger.info).toHaveBeenCalledTimes(0);
-      expect(logger.warn).toHaveBeenCalledTimes(0);
-      expect(logger.error).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -1636,7 +1636,7 @@ describe("BucketClient", () => {
 
     beforeEach(async () => {
       client = new BucketClient({ offline: true });
-      await client.initialize();
+      // no need to initialize in `offline` mode
     });
 
     it("should send not send, fetch or log anything", async () => {

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -1630,6 +1630,27 @@ describe("BucketClient", () => {
       );
     });
   });
+
+  describe("offline mode", () => {
+    let client: BucketClient;
+
+    beforeEach(async () => {
+      client = new BucketClient({ offline: true });
+      await client.initialize();
+    });
+
+    it("should send not send, fetch or log anything", async () => {
+      client.getFeatures({});
+
+      expect(httpClient.get).toHaveBeenCalledTimes(0);
+      expect(httpClient.post).toHaveBeenCalledTimes(0);
+
+      expect(logger.debug).toHaveBeenCalledTimes(0);
+      expect(logger.info).toHaveBeenCalledTimes(0);
+      expect(logger.warn).toHaveBeenCalledTimes(0);
+      expect(logger.error).toHaveBeenCalledTimes(0);
+    });
+  });
 });
 
 describe("BoundBucketClient", () => {

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -1639,7 +1639,7 @@ describe("BucketClient", () => {
         ...validOptions,
         offline: true,
       });
-      client.initialize();
+      await client.initialize();
     });
 
     it("should send not send or fetch anything", async () => {


### PR DESCRIPTION
In offline mode:
- batchBuffer interferes because it schedules callbacks which can leave tests hanging.
- no longer necessary to call `initialize` to avoid getting a warn log. 