### PR TITLE
add autoplacement middleware

### DIFF
--- a/packages/browser-sdk/src/feedback/ui/FeedbackDialog.tsx
+++ b/packages/browser-sdk/src/feedback/ui/FeedbackDialog.tsx
@@ -6,8 +6,8 @@ import { useTimer } from "./hooks/useTimer";
 import { Close } from "./icons/Close";
 import {
   arrow,
-  autoPlacement,
   autoUpdate,
+  flip,
   offset,
   shift,
   useFloating,
@@ -61,9 +61,14 @@ export const FeedbackDialog: FunctionComponent<FeedbackDialogProps> = ({
     transform: false,
     whileElementsMounted: autoUpdate,
     middleware: [
+      flip({
+        padding: 10,
+        mainAxis: true,
+        crossAxis: true,
+        fallbackAxisSideDirection: "end",
+      }),
       shift(),
       offset(8),
-      autoPlacement(),
       arrow({
         element: arrowRef,
       }),

--- a/packages/browser-sdk/src/feedback/ui/FeedbackDialog.tsx
+++ b/packages/browser-sdk/src/feedback/ui/FeedbackDialog.tsx
@@ -6,6 +6,7 @@ import { useTimer } from "./hooks/useTimer";
 import { Close } from "./icons/Close";
 import {
   arrow,
+  autoPlacement,
   autoUpdate,
   offset,
   shift,
@@ -62,6 +63,7 @@ export const FeedbackDialog: FunctionComponent<FeedbackDialogProps> = ({
     middleware: [
       shift(),
       offset(8),
+      autoPlacement(),
       arrow({
         element: arrowRef,
       }),


### PR DESCRIPTION
Positioning the widget in a popover state can be tricky given the various environments that it can used in. With the current positioning where `bottom` is preferred, it can result in very crowded placements if there's very little room for it.

Before, example:
<img width="425" alt="image" src="https://github.com/user-attachments/assets/a4dba184-e5be-427f-a540-ebef633b4a1d">

Using the `flip` middleware for floating UI, it will flip to another side when there's not enough room available in the preferred direction. It will prefer following placements, in this order: `bottom`, `top`, `right`, `left`.

After, example:
<img width="626" alt="image" src="https://github.com/user-attachments/assets/04518c79-93a5-4571-8732-db3fda9563fd">
