### PR TITLE
chore: updating playwright

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -10,7 +10,7 @@ on: [push]
 jobs:
   build-and-test:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@bucketco/eslint-config": "0.0.2",
     "@bucketco/tsconfig": "0.0.2",
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.48.0",
     "@types/node": "^20.14.0",
     "@types/webpack": "^5.28.5",
     "css-loader": "^6.9.0",

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@bucketco/eslint-config": "0.0.2",
     "@bucketco/tsconfig": "0.0.2",
-    "@playwright/test": "^1.48.0",
+    "@playwright/test": "^1.49.1",
     "@types/node": "^20.14.0",
     "@types/webpack": "^5.28.5",
     "css-loader": "^6.9.0",

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@bucketco/eslint-config": "0.0.2",
     "@bucketco/tsconfig": "0.0.2",
-    "@playwright/test": "^1.45.3",
+    "@playwright/test": "^1.49.1",
     "@types/node": "^20.14.0",
     "@types/webpack": "^5.28.5",
     "css-loader": "^6.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,7 +889,7 @@ __metadata:
     "@bucketco/eslint-config": "npm:0.0.2"
     "@bucketco/tsconfig": "npm:0.0.2"
     "@floating-ui/dom": "npm:^1.6.8"
-    "@playwright/test": "npm:^1.45.3"
+    "@playwright/test": "npm:^1.49.1"
     "@types/node": "npm:^20.14.0"
     "@types/webpack": "npm:^5.28.5"
     canonical-json: "npm:^0.0.4"
@@ -2821,14 +2821,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.45.3":
-  version: 1.45.3
-  resolution: "@playwright/test@npm:1.45.3"
+"@playwright/test@npm:^1.49.1":
+  version: 1.49.1
+  resolution: "@playwright/test@npm:1.49.1"
   dependencies:
-    playwright: "npm:1.45.3"
+    playwright: "npm:1.49.1"
   bin:
     playwright: cli.js
-  checksum: 10c0/d6c2179601093ae0e4feaf6a73841c62045102739d6607e38ea6ab820301f4659ee767c629479b3ce929d72a5f448819a6ee96b0c501fb39b90fceee83fafcde
+  checksum: 10c0/2fca0bb7b334f7a23c7c5dfa5dbe37b47794c56f39b747c8d74a2f95c339e7902a296f2f1dd32c47bdd723cfa92cee05219f1a5876725dc89a1871b9137a286d
   languageName: node
   linkType: hard
 
@@ -12041,12 +12041,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.45.3":
-  version: 1.45.3
-  resolution: "playwright-core@npm:1.45.3"
+"playwright-core@npm:1.49.1":
+  version: 1.49.1
+  resolution: "playwright-core@npm:1.49.1"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/39cc5920b27c42300e13a0646ca723578085d85940fc1f03e858fa348b5ac06f2eadf34cf15a0c0f4443e63ae188097d3ddbeb4389e7bbf5ae3438d8f6ed23e1
+  checksum: 10c0/990b619c75715cd98b2c10c1180a126e3a454b247063b8352bc67792fe01183ec07f31d30c8714c3768cefed12886d1d64ac06da701f2baafc2cad9b439e3919
   languageName: node
   linkType: hard
 
@@ -12065,18 +12065,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright@npm:1.45.3":
-  version: 1.45.3
-  resolution: "playwright@npm:1.45.3"
+"playwright@npm:1.49.1":
+  version: 1.49.1
+  resolution: "playwright@npm:1.49.1"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.45.3"
+    playwright-core: "npm:1.49.1"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/3516ca49deb589171ac6525c0367f2ff948514d791d197f3cc0a135154c2df08a4d7cd11a810e187f35ae9ca490b37ca3a92fb3eb51560f03aefcaca0613efdb
+  checksum: 10c0/2368762c898920d4a0a5788b153dead45f9c36c3f5cf4d2af5228d0b8ea65823e3bbe998877950a2b9bb23a211e4633996f854c6188769dc81a25543ac818ab5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,7 +889,7 @@ __metadata:
     "@bucketco/eslint-config": "npm:0.0.2"
     "@bucketco/tsconfig": "npm:0.0.2"
     "@floating-ui/dom": "npm:^1.6.8"
-    "@playwright/test": "npm:^1.49.1"
+    "@playwright/test": "npm:^1.48.0"
     "@types/node": "npm:^20.14.0"
     "@types/webpack": "npm:^5.28.5"
     canonical-json: "npm:^0.0.4"
@@ -2821,7 +2821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.49.1":
+"@playwright/test@npm:^1.48.0":
   version: 1.49.1
   resolution: "@playwright/test@npm:1.49.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,7 +889,7 @@ __metadata:
     "@bucketco/eslint-config": "npm:0.0.2"
     "@bucketco/tsconfig": "npm:0.0.2"
     "@floating-ui/dom": "npm:^1.6.8"
-    "@playwright/test": "npm:^1.48.0"
+    "@playwright/test": "npm:^1.49.1"
     "@types/node": "npm:^20.14.0"
     "@types/webpack": "npm:^5.28.5"
     canonical-json: "npm:^0.0.4"
@@ -2821,7 +2821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.48.0":
+"@playwright/test@npm:^1.49.1":
   version: 1.49.1
   resolution: "@playwright/test@npm:1.49.1"
   dependencies:


### PR DESCRIPTION
Tests are currently failing due to an updated base image which no longer
contains the playwright dependencies:
https://github.com/bucketco/bucket-javascript-sdk/actions/runs/12380013335/job/34555430888