### PR TITLE
Refactor SDK to use updated `evaluateFeatureRules` API

### DIFF
--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/browser-sdk",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "packageManager": "yarn@4.1.1",
   "license": "MIT",
   "repository": {

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -191,57 +191,6 @@ export class BucketClient {
   }
 
   /**
-   * Send attributes to Bucket for the current user
-   */
-  private async user() {
-    if (!this.context.user) {
-      this.logger.warn(
-        "`user` call ignored. No user context provided at initialization",
-      );
-      return;
-    }
-
-    const { id, ...attributes } = this.context.user;
-    const payload: User = {
-      userId: String(id),
-      attributes,
-    };
-    const res = await this.httpClient.post({ path: `/user`, body: payload });
-    this.logger.debug(`sent user`, res);
-    return res;
-  }
-
-  /**
-   * Send attributes to Bucket for the current company.
-   */
-  private async company() {
-    if (!this.context.user) {
-      this.logger.warn(
-        "`company` call ignored. No user context provided at initialization",
-      );
-      return;
-    }
-
-    if (!this.context.company) {
-      this.logger.warn(
-        "`company` call ignored. No company context provided at initialization",
-      );
-      return;
-    }
-
-    const { id, ...attributes } = this.context.company;
-    const payload: Company = {
-      userId: String(this.context.user.id),
-      companyId: String(id),
-      attributes,
-    };
-
-    const res = await this.httpClient.post({ path: `/company`, body: payload });
-    this.logger.debug(`sent company`, res);
-    return res;
-  }
-
-  /**
    * Track an event in Bucket.
    *
    * @param eventName The name of the event
@@ -273,8 +222,8 @@ export class BucketClient {
   /**
    * Submit user feedback to Bucket. Must include either `score` or `comment`, or both.
    *
-   * @param options
    * @returns
+   * @param payload
    */
   async feedback(payload: Feedback) {
     const userId =
@@ -423,5 +372,56 @@ export class BucketClient {
       await this.autoFeedbackInit;
       this.autoFeedback.stop();
     }
+  }
+
+  /**
+   * Send attributes to Bucket for the current user
+   */
+  private async user() {
+    if (!this.context.user) {
+      this.logger.warn(
+        "`user` call ignored. No user context provided at initialization",
+      );
+      return;
+    }
+
+    const { id, ...attributes } = this.context.user;
+    const payload: User = {
+      userId: String(id),
+      attributes,
+    };
+    const res = await this.httpClient.post({ path: `/user`, body: payload });
+    this.logger.debug(`sent user`, res);
+    return res;
+  }
+
+  /**
+   * Send attributes to Bucket for the current company.
+   */
+  private async company() {
+    if (!this.context.user) {
+      this.logger.warn(
+        "`company` call ignored. No user context provided at initialization",
+      );
+      return;
+    }
+
+    if (!this.context.company) {
+      this.logger.warn(
+        "`company` call ignored. No company context provided at initialization",
+      );
+      return;
+    }
+
+    const { id, ...attributes } = this.context.company;
+    const payload: Company = {
+      userId: String(this.context.user.id),
+      companyId: String(id),
+      attributes,
+    };
+
+    const res = await this.httpClient.post({ path: `/company`, body: payload });
+    this.logger.debug(`sent company`, res);
+    return res;
   }
 }

--- a/packages/browser-sdk/src/feature/features.ts
+++ b/packages/browser-sdk/src/feature/features.ts
@@ -38,27 +38,6 @@ export const DEFAULT_FEATURES_CONFIG: Config = {
 };
 
 // Deep merge two objects.
-export function mergeDeep(
-  target: Record<string, any>,
-  ...sources: Record<string, any>[]
-): Record<string, any> {
-  if (!sources.length) return target;
-  const source = sources.shift();
-
-  if (isObject(target) && isObject(source)) {
-    for (const key in source) {
-      if (isObject(source[key])) {
-        if (!target[key]) Object.assign(target, { [key]: {} });
-        mergeDeep(target[key], source[key]);
-      } else {
-        Object.assign(target, { [key]: source[key] });
-      }
-    }
-  }
-
-  return mergeDeep(target, ...sources);
-}
-
 export type FeaturesResponse = {
   success: boolean;
   features: RawFeatures;
@@ -91,18 +70,13 @@ export function flattenJSON(obj: Record<string, any>): Record<string, any> {
       for (const flatKey in flat) {
         result[`${key}.${flatKey}`] = flat[flatKey];
       }
-    } else if (typeof obj[key] === "undefined") {
-      continue;
-    } else {
+    } else if (typeof obj[key] !== "undefined") {
       result[key] = obj[key];
     }
   }
   return result;
 }
 
-export function clearFeatureCache() {
-  localStorage.clear();
-}
 export interface CheckEvent {
   key: string;
   value: boolean;
@@ -118,7 +92,7 @@ export class FeaturesClient {
   private features: RawFeatures;
   private config: Config;
   private rateLimiter: RateLimiter;
-  private logger: Logger;
+  private readonly logger: Logger;
 
   constructor(
     private httpClient: HttpClient,
@@ -156,77 +130,8 @@ export class FeaturesClient {
     this.setFeatures(features);
   }
 
-  private setFeatures(features: RawFeatures) {
-    this.features = features;
-  }
-
   getFeatures(): RawFeatures {
     return this.features;
-  }
-
-  private fetchParams() {
-    const flattenedContext = flattenJSON({ context: this.context });
-    const params = new URLSearchParams(flattenedContext);
-    // publishableKey should be part of the cache key
-    params.append("publishableKey", this.httpClient.publishableKey);
-
-    // sort the params to ensure that the URL is the same for the same context
-    params.sort();
-
-    return params;
-  }
-
-  private async maybeFetchFeatures(): Promise<RawFeatures | undefined> {
-    const cacheKey = this.fetchParams().toString();
-    const cachedItem = this.cache.get(cacheKey);
-
-    if (cachedItem) {
-      if (!cachedItem.stale) return cachedItem.features;
-
-      // serve successful stale cache if `staleWhileRevalidate` is enabled
-      if (this.config.staleWhileRevalidate) {
-        // re-fetch in the background, but immediately return last successful value
-        this.fetchFeatures()
-          .then((features) => {
-            if (!features) return;
-
-            this.cache.set(cacheKey, {
-              features,
-            });
-            this.setFeatures(features);
-          })
-          .catch(() => {
-            // we don't care about the result, we just want to re-fetch
-          });
-        return cachedItem.features;
-      }
-    }
-
-    // if there's no cached item or there is a stale one but `staleWhileRevalidate` is disabled
-    // try fetching a new one
-    const fetchedFeatures = await this.fetchFeatures();
-
-    if (fetchedFeatures) {
-      this.cache.set(cacheKey, {
-        features: fetchedFeatures,
-      });
-
-      return fetchedFeatures;
-    }
-
-    if (cachedItem) {
-      // fetch failed, return stale cache
-      return cachedItem.features;
-    }
-
-    // fetch failed, nothing cached => return fallbacks
-    return this.config.fallbackFeatures.reduce((acc, key) => {
-      acc[key] = {
-        key,
-        isEnabled: true,
-      };
-      return acc;
-    }, {} as RawFeatures);
   }
 
   public async fetchFeatures(): Promise<RawFeatures | undefined> {
@@ -296,5 +201,74 @@ export class FeaturesClient {
     });
 
     return checkEvent.value;
+  }
+
+  private setFeatures(features: RawFeatures) {
+    this.features = features;
+  }
+
+  private fetchParams() {
+    const flattenedContext = flattenJSON({ context: this.context });
+    const params = new URLSearchParams(flattenedContext);
+    // publishableKey should be part of the cache key
+    params.append("publishableKey", this.httpClient.publishableKey);
+
+    // sort the params to ensure that the URL is the same for the same context
+    params.sort();
+
+    return params;
+  }
+
+  private async maybeFetchFeatures(): Promise<RawFeatures | undefined> {
+    const cacheKey = this.fetchParams().toString();
+    const cachedItem = this.cache.get(cacheKey);
+
+    if (cachedItem) {
+      if (!cachedItem.stale) return cachedItem.features;
+
+      // serve successful stale cache if `staleWhileRevalidate` is enabled
+      if (this.config.staleWhileRevalidate) {
+        // re-fetch in the background, but immediately return last successful value
+        this.fetchFeatures()
+          .then((features) => {
+            if (!features) return;
+
+            this.cache.set(cacheKey, {
+              features,
+            });
+            this.setFeatures(features);
+          })
+          .catch(() => {
+            // we don't care about the result, we just want to re-fetch
+          });
+        return cachedItem.features;
+      }
+    }
+
+    // if there's no cached item or there is a stale one but `staleWhileRevalidate` is disabled
+    // try fetching a new one
+    const fetchedFeatures = await this.fetchFeatures();
+
+    if (fetchedFeatures) {
+      this.cache.set(cacheKey, {
+        features: fetchedFeatures,
+      });
+
+      return fetchedFeatures;
+    }
+
+    if (cachedItem) {
+      // fetch failed, return stale cache
+      return cachedItem.features;
+    }
+
+    // fetch failed, nothing cached => return fallbacks
+    return this.config.fallbackFeatures.reduce((acc, key) => {
+      acc[key] = {
+        key,
+        isEnabled: true,
+      };
+      return acc;
+    }, {} as RawFeatures);
   }
 }

--- a/packages/flag-evaluation/package.json
+++ b/packages/flag-evaluation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/flag-evaluation",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/flag-evaluation/package.json
+++ b/packages/flag-evaluation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/flag-evaluation",
-  "version": "0.0.7",
+  "version": "1.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { createHash } from "node:crypto";
 
 /**
@@ -239,8 +238,9 @@ export function unflattenJSON(data: Record<string, any>): Record<string, any> {
     const keys = i.split(".");
     keys.reduce((acc, key, index) => {
       if (index === keys.length - 1) {
-        assert(typeof acc === "object", "overlapping keys");
-        acc[key] = data[i];
+        if (typeof acc === "object") {
+          acc[key] = data[i];
+        }
       } else if (!acc[key]) {
         acc[key] = {};
       }

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -1,49 +1,81 @@
+import assert from "node:assert";
 import { createHash } from "node:crypto";
 
+/**
+ * Represents a filter class with a specific type property.
+ *
+ * This type is intended to define the structure for objects
+ * that classify or categorize based on a particular filter type.
+ *
+ * Properties:
+ * - type: Specifies the classification type as a string.
+ */
 export type FilterClass = {
   type: string;
 };
 
+/**
+ * Represents a group of filters that can be combined with a logical operator.
+ *
+ * @template T The type of filter class that defines the criteria within the filter group.
+ * @property type The fixed type indicator for this filter structure, always "group".
+ * @property operator The logical operator used to combine the filters in the group. It can be either "and" (all conditions must pass) or "or" (at least one condition must pass).
+ * @property filters An array of filter trees containing individual filters or nested groups of filters.
+ */
 export type FilterGroup<T extends FilterClass> = {
   type: "group";
   operator: "and" | "or";
   filters: FilterTree<T>[];
 };
 
+/**
+ * Represents a filter negation structure for use within filtering systems.
+ *
+ * A `FilterNegation` is used to encapsulate a negation operation,
+ * which negates the conditions defined in the provided `filter`.
+ *
+ * @template T - A generic type that extends FilterClass, indicating the type of the filter.
+ * @property type - Specifies the type of this filter operation as "negation".
+ * @property filter - A `FilterTree` structure of type `T` that defines the filter conditions to be negated.
+ */
 export type FilterNegation<T extends FilterClass> = {
   type: "negation";
   filter: FilterTree<T>;
 };
 
+/**
+ * Represents a tree structure for filters that can be composed of filter groups,
+ * filter negations, or individual filter instances of a specified type.
+ *
+ * @template T - A type that extends the `FilterClass`.
+ */
 export type FilterTree<T extends FilterClass> =
   | FilterGroup<T>
   | FilterNegation<T>
   | T;
 
-export interface Rule {
-  filter: RuleFilter;
-}
-
-export type FeatureData = {
-  key: string;
-  targeting: { rules: Rule[] };
-};
-
-export interface EvaluateTargetingParams {
-  context: Record<string, unknown>;
-  feature: FeatureData;
-}
-
-export interface EvaluateTargetingResult {
-  value: boolean;
-  feature: FeatureData;
-  context: Record<string, any>;
-  ruleEvaluationResults: boolean[];
-  reason?: string;
-  missingContextFields?: string[];
-}
-
-type ContextFilterOp =
+/**
+ * Represents a set of predefined operators that can be used to filter a specific context.
+ * These operators can express various conditions, including equality checks, comparison,
+ * set membership, and boolean evaluations.
+ *
+ * Possible values:
+ * - "IS": Specifies exact match.
+ * - "IS_NOT": Specifies a negation of exact match.
+ * - "ANY_OF": Checks if a value is present in a set of specified values.
+ * - "NOT_ANY_OF": Checks if a value is not present in a set of specified values.
+ * - "CONTAINS": Verifies if a value contains a specific substring or element.
+ * - "NOT_CONTAINS": Verifies if a value does not contain a specific substring or element.
+ * - "GT": Greater than comparison.
+ * - "LT": Less than comparison.
+ * - "AFTER": Compares if a value is after a specified point (e.g., time, rank).
+ * - "BEFORE": Compares if a value is before a specified point (e.g., time, rank).
+ * - "SET": Checks if a value is set or exists.
+ * - "NOT_SET": Checks if a value is not set or does not exist.
+ * - "IS_TRUE": Checks if a boolean value is true.
+ * - "IS_FALSE": Checks if a boolean value is false.
+ */
+type ContextFilterOperator =
   | "IS"
   | "IS_NOT"
   | "ANY_OF"
@@ -59,13 +91,46 @@ type ContextFilterOp =
   | "IS_TRUE"
   | "IS_FALSE";
 
-export type ContextFilter = {
+/**
+ * Represents a filter configuration used to filter data based on specific context.
+ *
+ * This interface defines the structure of a context filter, containing a field,
+ * an operator, and optional values to control the filtering behavior.
+ *
+ * The `type` property must always have the value "context" to classify filters
+ * of this type.
+ *
+ * The `field` property specifies the name of the context field to filter.
+ *
+ * The `operator` property defines the filtering operation to perform on the
+ * specified field (e.g., equals, contains, etc.).
+ *
+ * The optional `values` property is an array of strings that lists the values
+ * to be used in conjunction with the operator for filtering.
+ *
+ * This interface is typically utilized in contexts where data needs to be
+ * dynamically filtered based on specific criteria derived from contextual
+ * attributes.
+ */
+export interface ContextFilter {
   type: "context";
   field: string;
-  operator: ContextFilterOp;
+  operator: ContextFilterOperator;
   values?: string[];
-};
+}
 
+/**
+ * Represents a filter configuration to enable percentage-based rollout of a feature or functionality.
+ *
+ * This type defines the necessary parameters to control access to a feature
+ * by evaluating a specific attribute and applying it against a defined percentage threshold.
+ *
+ * Properties:
+ * - `type` - Indicates the type of the filter. For this filter type, it will always be "rolloutPercentage".
+ * - `key` - A unique key or identifier that distinguishes this rollout filter.
+ * - `partialRolloutAttribute` - Specifies the attribute used to evaluate eligibility for the rollout.
+ * - `partialRolloutThreshold` - A numeric value representing the upper-bound threshold (0-100) for the percentage-based rollout.
+ */
 export type PercentageRolloutFilter = {
   type: "rolloutPercentage";
   key: string;
@@ -73,15 +138,70 @@ export type PercentageRolloutFilter = {
   partialRolloutThreshold: number;
 };
 
+/**
+ * Represents a constant filter configuration.
+ *
+ * The ConstantFilter type is used to define a filter configuration with a fixed,
+ * immutable value. It always evaluates to the specified boolean `value`.
+ *
+ * @property {string} type - Indicates the type of filter, which is always "constant".
+ * @property {boolean} value - The fixed boolean value for the filter.
+ */
 export type ConstantFilter = {
   type: "constant";
   value: boolean;
 };
 
+/**
+ * A composite type for representing a rule-based filter system.
+ *
+ * This type is constructed using a `FilterTree` structure that consists of
+ * nested filters of the following types:
+ * - `ContextFilter`: A filter that evaluates based on specified context criteria.
+ * - `PercentageRolloutFilter`: A filter that performs a percentage-based rollout.
+ * - `ConstantFilter`: A filter that evaluates based on fixed conditions or constants.
+ *
+ * `RuleFilter` is typically used in scenarios where a hierarchical filtering mechanism
+ * is needed to determine outcomes based on multiple layered conditions.
+ */
 export type RuleFilter = FilterTree<
   ContextFilter | PercentageRolloutFilter | ConstantFilter
 >;
 
+/**
+ * Represents a value that can be used in a rule configuration.
+ *
+ * RuleValue can take on different types, allowing flexibility based on the
+ * specific rule's requirements. This can include:
+ * - A boolean value: to represent true/false conditions.
+ * - A string: typically used for textual or keyword-based rules.
+ * - A number: for numerical rules or thresholds.
+ * - An object: for more complex rule definitions or configurations.
+ *
+ * This type is useful for accommodating various rule structures in applications
+ * that work with dynamic or user-defined regulations.
+ */
+type RuleValue = boolean | string | number | object;
+
+/**
+ * Represents a rule that defines a filtering criterion and an associated value.
+ *
+ * @template T - Specifies the type of the associated value that extends RuleValue.
+ * @property {RuleFilter} filter - The filtering criterion used by the rule.
+ * @property {T} value - The value associated with the rule.
+ */
+export interface Rule<T extends RuleValue> {
+  filter: RuleFilter;
+  value: T;
+}
+
+/**
+ * Flattens a nested JSON object into a single-level object, with keys indicating the nesting levels.
+ * Keys in the resulting object are represented in a dot notation to reflect the nesting structure of the original data.
+ *
+ * @param {object} data - The nested JSON object to be flattened.
+ * @return {Record<string, string>} A flattened JSON object with "stringified" keys and values.
+ */
 export function flattenJSON(data: object): Record<string, string> {
   if (Object.keys(data).length === 0) return {};
   const result: Record<string, any> = {};
@@ -106,17 +226,25 @@ export function flattenJSON(data: object): Record<string, string> {
   return result;
 }
 
-export function unflattenJSON(data: Record<string, any>) {
+/**
+ * Converts a flattened JSON object with dot-separated keys into a nested JSON object.
+ *
+ * @param {Record<string, any>} data - The flattened JSON object where keys are dot-separated representing nested levels.
+ * @return {Record<string, any>} The unflattened JSON object with nested structure restored.
+ */
+export function unflattenJSON(data: Record<string, any>): Record<string, any> {
   const result: Record<string, any> = {};
 
   for (const i in data) {
     const keys = i.split(".");
     keys.reduce((acc, key, index) => {
       if (index === keys.length - 1) {
+        assert(typeof acc === "object", "overlapping keys");
         acc[key] = data[i];
       } else if (!acc[key]) {
         acc[key] = {};
       }
+
       return acc[key];
     }, result);
   }
@@ -124,31 +252,14 @@ export function unflattenJSON(data: Record<string, any>) {
   return result;
 }
 
-export function evaluateTargeting({
-  context,
-  feature,
-}: EvaluateTargetingParams): EvaluateTargetingResult {
-  const flatContext = flattenJSON(context);
-
-  const missingContextFieldsSet = new Set<string>();
-
-  const ruleEvaluationResults = feature.targeting.rules.map((rule) =>
-    evaluateRecursively(rule.filter, flatContext, missingContextFieldsSet),
-  );
-  const missingContextFields = Array.from(missingContextFieldsSet);
-
-  const firstIdx = ruleEvaluationResults.findIndex(Boolean);
-  return {
-    value: firstIdx > -1,
-    feature,
-    context: flatContext,
-    ruleEvaluationResults,
-    reason: firstIdx > -1 ? `rule #${firstIdx} matched` : "no matched rules",
-    missingContextFields,
-  };
-}
-
-export function hashInt(hashInput: string) {
+/**
+ * Generates a hashed integer based on the input string. The method extracts 20 bits from the hash,
+ * scales it to a range between 0 and 100000, and returns the resultant integer.
+ *
+ * @param {string} hashInput - The input string used to generate the hash.
+ * @return {number} A number between 0 and 100000 derived from the hash of the input string.
+ */
+export function hashInt(hashInput: string): number {
   // 1. hash the key and the partial rollout attribute
   // 2. take 20 bits from the hash and divide by 2^20 - 1 to get a number between 0 and 1
   // 3. multiply by 100000 to get a number between 0 and 100000 and compare it to the threshold
@@ -158,6 +269,74 @@ export function hashInt(hashInput: string) {
     createHash("sha256").update(hashInput, "utf-8").digest().readUInt32LE(0) &
     0xfffff;
   return Math.floor((hash / 0xfffff) * 100000);
+}
+
+/**
+ * Evaluates a field value against a specified operator and comparison values.
+ *
+ * @param {string} fieldValue - The value to be evaluated.
+ * @param {ContextFilterOperator} operator - The operator used for the evaluation (e.g., "CONTAINS", "GT").
+ * @param {string[]} values - An array of comparison values for evaluation.
+ * @return {boolean} The result of the evaluation based on the operator and comparison values.
+ */
+export function evaluate(
+  fieldValue: string,
+  operator: ContextFilterOperator,
+  values: string[],
+): boolean {
+  const value = values[0];
+
+  switch (operator) {
+    case "CONTAINS":
+      return fieldValue.toLowerCase().includes(value.toLowerCase());
+    case "NOT_CONTAINS":
+      return !fieldValue.toLowerCase().includes(value.toLowerCase());
+    case "GT":
+      if (isNaN(Number(fieldValue)) || isNaN(Number(value))) {
+        // TODO: return error instead? used logger previously
+        console.error(
+          `GT operator requires numeric values: ${fieldValue}, ${value}`,
+        );
+        return false;
+      }
+      return fieldValue > value;
+    case "LT":
+      if (isNaN(Number(fieldValue)) || isNaN(Number(value))) {
+        console.error(
+          `LT operator requires numeric values: ${fieldValue}, ${value}`,
+        );
+        return false;
+      }
+      return fieldValue < value;
+    case "AFTER":
+    case "BEFORE": {
+      // more/less than `value` days ago
+      const daysAgo = new Date();
+      daysAgo.setDate(daysAgo.getDate() - Number(value));
+      const fieldValueDate = new Date(fieldValue).getTime();
+
+      return operator === "AFTER"
+        ? fieldValueDate > daysAgo.getTime()
+        : fieldValueDate < daysAgo.getTime();
+    }
+    case "SET":
+      return fieldValue != "";
+    case "IS":
+      return fieldValue === value;
+    case "IS_NOT":
+      return fieldValue !== value;
+    case "ANY_OF":
+      return values.includes(fieldValue);
+    case "NOT_ANY_OF":
+      return !values.includes(fieldValue);
+    case "IS_TRUE":
+      return fieldValue == "true";
+    case "IS_FALSE":
+      return fieldValue == "false";
+    default:
+      console.error(`unknown operator: ${operator}`);
+      return false;
+  }
 }
 
 function evaluateRecursively(
@@ -214,62 +393,68 @@ function evaluateRecursively(
   }
 }
 
-export function evaluate(
-  fieldValue: string,
-  op: ContextFilterOp,
-  values: string[],
-) {
-  const value = values[0];
+/**
+ * Represents the parameters required for evaluating rules against a specific feature in a given context.
+ *
+ * @template T - The type of the rule value used in evaluation.
+ *
+ * @property {string} featureKey - The key that identifies the specific feature to be evaluated.
+ * @property {Rule<T>[]} rules - An array of rules used for evaluation.
+ * @property {Record<string, unknown>} context - The contextual data used during the evaluation process.
+ */
+export interface EvaluationParams<T extends RuleValue> {
+  featureKey: string;
+  rules: Rule<T>[];
+  context: Record<string, unknown>;
+}
 
-  switch (op) {
-    case "CONTAINS":
-      return fieldValue.toLowerCase().includes(value.toLowerCase());
-    case "NOT_CONTAINS":
-      return !fieldValue.toLowerCase().includes(value.toLowerCase());
-    case "GT":
-      if (isNaN(Number(fieldValue)) || isNaN(Number(value))) {
-        // TODO: return error instead? used logger previously
-        console.error(
-          `GT operator requires numeric values: ${fieldValue}, ${value}`,
-        );
-        return false;
-      }
-      return fieldValue > value;
-    case "LT":
-      if (isNaN(Number(fieldValue)) || isNaN(Number(value))) {
-        console.error(
-          `LT operator requires numeric values: ${fieldValue}, ${value}`,
-        );
-        return false;
-      }
-      return fieldValue < value;
-    case "AFTER":
-    case "BEFORE": {
-      // more/less than `value` days ago
-      const daysAgo = new Date();
-      daysAgo.setDate(daysAgo.getDate() - Number(value));
-      const fieldValueDate = new Date(fieldValue).getTime();
+/**
+ * Represents the result of an evaluation process for a specific feature and its associated rules.
+ *
+ * @template T - The type of the rule value being evaluated.
+ *
+ * @property {string} featureKey - The unique key identifying the feature being evaluated.
+ * @property {T | undefined} value - The resolved value of the feature, if the evaluation is successful.
+ * @property {Record<string, any>} context - The contextual information used during the evaluation process.
+ * @property {boolean[]} ruleEvaluationResults - Array indicating the success or failure of each rule evaluated.
+ * @property {string} [reason] - Optional field providing additional explanation regarding the evaluation result.
+ * @property {string[]} [missingContextFields] - Optional array of context fields that were required but not provided during the evaluation.
+ */
+export interface EvaluationResult<T extends RuleValue> {
+  featureKey: string;
+  value: T | undefined;
+  context: Record<string, any>;
+  ruleEvaluationResults: boolean[];
+  reason?: string;
+  missingContextFields?: string[];
+}
 
-      return op === "AFTER"
-        ? fieldValueDate > daysAgo.getTime()
-        : fieldValueDate < daysAgo.getTime();
-    }
-    case "SET":
-      return fieldValue != "";
-    case "IS":
-      return fieldValue === value;
-    case "IS_NOT":
-      return fieldValue !== value;
-    case "ANY_OF":
-      return values.includes(fieldValue);
-    case "NOT_ANY_OF":
-      return !values.includes(fieldValue);
-    case "IS_TRUE":
-      return fieldValue == "true";
-    case "IS_FALSE":
-      return fieldValue == "false";
-    default:
-      console.error(`unknown operator: ${op}`);
-      return false;
-  }
+export function evaluateFeatureRules<T extends RuleValue>({
+  context,
+  featureKey,
+  rules,
+}: EvaluationParams<T>): EvaluationResult<T> {
+  const flatContext = flattenJSON(context);
+  const missingContextFieldsSet = new Set<string>();
+
+  const ruleEvaluationResults = rules.map((rule) =>
+    evaluateRecursively(rule.filter, flatContext, missingContextFieldsSet),
+  );
+
+  const missingContextFields = Array.from(missingContextFieldsSet);
+
+  const firstMatchedRuleIndex = ruleEvaluationResults.findIndex(Boolean);
+  const firstMatchedRule =
+    firstMatchedRuleIndex > -1 ? rules[firstMatchedRuleIndex] : undefined;
+  return {
+    value: firstMatchedRule?.value,
+    featureKey,
+    context: flatContext,
+    ruleEvaluationResults,
+    reason:
+      firstMatchedRuleIndex > -1
+        ? `rule #${firstMatchedRuleIndex} matched`
+        : "no matched rules",
+    missingContextFields,
+  };
 }

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -558,13 +558,14 @@ describe("unflattenJSON", () => {
     });
   });
 
-  it("should correctly handle scenarios with overlapping keys", () => {
+  it("should correctly handle scenarios with overlapping keys (ignore)", () => {
     const input = {
       "a.b": "value1",
       "a.b.c": "value2",
     };
 
-    expect(() => unflattenJSON(input)).toThrow("overlapping keys");
+    const output = unflattenJSON(input);
+    expect(output).toEqual({ a: { b: "value1" } });
   });
 
   it("should unflatten nested objects correctly", () => {

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -1,101 +1,99 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { evaluate, evaluateTargeting, FeatureData, hashInt } from "../src";
+import {
+  evaluate,
+  evaluateFeatureRules,
+  EvaluationParams,
+  flattenJSON,
+  hashInt,
+  unflattenJSON,
+} from "../src";
 
-const feature: FeatureData = {
-  key: "feature",
-  targeting: {
-    rules: [
-      {
-        filter: {
-          type: "group",
-          operator: "and",
-          filters: [
-            {
-              type: "context",
-              field: "company.id",
-              operator: "IS",
-              values: ["company1"],
-            },
-            {
-              type: "rolloutPercentage",
-              key: "flag",
-              partialRolloutAttribute: "company.id",
-              partialRolloutThreshold: 100000,
-            },
-          ],
-        },
-      },
-    ],
-  },
-};
-
-describe("evaluate feature targeting integration ", () => {
-  it("evaluates all kinds of filters", async () => {
-    // Feature with context filter targeting, rollout percentage AND and OR groups, negation and constant filters
-    const featureWithAllFilterTypes: FeatureData = {
-      key: "feature",
-      targeting: {
-        rules: [
+const feature = {
+  featureKey: "feature",
+  rules: [
+    {
+      value: true,
+      filter: {
+        type: "group",
+        operator: "and",
+        filters: [
           {
-            filter: {
-              type: "group",
-              operator: "and",
-              filters: [
-                {
-                  type: "context",
-                  field: "company.id",
-                  operator: "IS",
-                  values: ["company1"],
-                },
-                {
-                  type: "rolloutPercentage",
-                  key: "flag",
-                  partialRolloutAttribute: "company.id",
-                  partialRolloutThreshold: 99999,
-                },
-                {
-                  type: "group",
-                  operator: "or",
-                  filters: [
-                    {
-                      type: "context",
-                      field: "company.id",
-                      operator: "IS",
-                      values: ["company2"],
-                    },
-                    {
-                      type: "negation",
-                      filter: {
-                        type: "context",
-                        field: "company.id",
-                        operator: "IS",
-                        values: ["company3"],
-                      },
-                    },
-                  ],
-                },
-                {
-                  type: "negation",
-                  filter: {
-                    type: "constant",
-                    value: false,
-                  },
-                },
-              ],
-            },
+            type: "context",
+            field: "company.id",
+            operator: "IS",
+            values: ["company1"],
+          },
+          {
+            type: "rolloutPercentage",
+            key: "flag",
+            partialRolloutAttribute: "company.id",
+            partialRolloutThreshold: 100000,
           },
         ],
       },
-    };
+    },
+  ],
+} satisfies Omit<EvaluationParams<true>, "context">;
 
-    const context = {
-      "company.id": "company1",
-    };
-
-    const res = evaluateTargeting({
-      feature: featureWithAllFilterTypes,
-      context,
+describe("evaluate feature targeting integration ", () => {
+  it("evaluates all kinds of filters", async () => {
+    const res = evaluateFeatureRules({
+      featureKey: "feature",
+      rules: [
+        {
+          value: true,
+          filter: {
+            type: "group",
+            operator: "and",
+            filters: [
+              {
+                type: "context",
+                field: "company.id",
+                operator: "IS",
+                values: ["company1"],
+              },
+              {
+                type: "rolloutPercentage",
+                key: "flag",
+                partialRolloutAttribute: "company.id",
+                partialRolloutThreshold: 99999,
+              },
+              {
+                type: "group",
+                operator: "or",
+                filters: [
+                  {
+                    type: "context",
+                    field: "company.id",
+                    operator: "IS",
+                    values: ["company2"],
+                  },
+                  {
+                    type: "negation",
+                    filter: {
+                      type: "context",
+                      field: "company.id",
+                      operator: "IS",
+                      values: ["company3"],
+                    },
+                  },
+                ],
+              },
+              {
+                type: "negation",
+                filter: {
+                  type: "constant",
+                  value: false,
+                },
+              },
+            ],
+          },
+        },
+      ],
+      context: {
+        "company.id": "company1",
+      },
     });
 
     expect(res).toEqual({
@@ -103,7 +101,7 @@ describe("evaluate feature targeting integration ", () => {
       context: {
         "company.id": "company1",
       },
-      feature: featureWithAllFilterTypes,
+      featureKey: "feature",
       missingContextFields: [],
       reason: "rule #0 matched",
       ruleEvaluationResults: [true],
@@ -111,8 +109,8 @@ describe("evaluate feature targeting integration ", () => {
   });
 
   it("evaluates flag when there's no matching rule", async () => {
-    const res = evaluateTargeting({
-      feature,
+    const res = evaluateFeatureRules({
+      ...feature,
       context: {
         company: {
           id: "wrong value",
@@ -121,11 +119,11 @@ describe("evaluate feature targeting integration ", () => {
     });
 
     expect(res).toEqual({
-      value: false,
+      value: undefined,
       context: {
         "company.id": "wrong value",
       },
-      feature,
+      featureKey: "feature",
       missingContextFields: [],
       reason: "no matched rules",
       ruleEvaluationResults: [false],
@@ -138,16 +136,18 @@ describe("evaluate feature targeting integration ", () => {
         id: "company1",
       },
     };
-    const res = evaluateTargeting({
-      feature,
+
+    const res = evaluateFeatureRules({
+      ...feature,
       context,
     });
+
     expect(res).toEqual({
       value: true,
       context: {
         "company.id": "company1",
       },
-      feature,
+      featureKey: "feature",
       missingContextFields: [],
       reason: "rule #0 matched",
       ruleEvaluationResults: [true],
@@ -155,36 +155,31 @@ describe("evaluate feature targeting integration ", () => {
   });
 
   it("evaluates flag with missing values", async () => {
-    const featureWithSegmentRule: FeatureData = {
-      key: "feature",
-      targeting: {
-        rules: [
-          {
-            filter: {
-              type: "group",
-              operator: "and",
-              filters: [
-                {
-                  type: "context",
-                  field: "some_field",
-                  operator: "IS",
-                  values: [""],
-                },
-                {
-                  type: "rolloutPercentage",
-                  key: "flag",
-                  partialRolloutAttribute: "some_field",
-                  partialRolloutThreshold: 99000,
-                },
-              ],
-            },
+    const res = evaluateFeatureRules({
+      featureKey: "feature",
+      rules: [
+        {
+          value: { custom: "value" },
+          filter: {
+            type: "group",
+            operator: "and",
+            filters: [
+              {
+                type: "context",
+                field: "some_field",
+                operator: "IS",
+                values: [""],
+              },
+              {
+                type: "rolloutPercentage",
+                key: "flag",
+                partialRolloutAttribute: "some_field",
+                partialRolloutThreshold: 99000,
+              },
+            ],
           },
-        ],
-      },
-    };
-
-    const res = evaluateTargeting({
-      feature: featureWithSegmentRule,
+        },
+      ],
       context: {
         some_field: "",
       },
@@ -194,8 +189,8 @@ describe("evaluate feature targeting integration ", () => {
       context: {
         some_field: "",
       },
-      value: true,
-      feature: featureWithSegmentRule,
+      value: { custom: "value" },
+      featureKey: "feature",
       missingContextFields: [],
       reason: "rule #0 matched",
       ruleEvaluationResults: [true],
@@ -203,44 +198,42 @@ describe("evaluate feature targeting integration ", () => {
   });
 
   it("returns list of missing context keys ", async () => {
-    const res = evaluateTargeting({
-      feature: feature,
+    const res = evaluateFeatureRules({
+      ...feature,
       context: {},
     });
+
     expect(res).toEqual({
       context: {},
-      value: false,
+      value: undefined,
       reason: "no matched rules",
-      feature,
+      featureKey: "feature",
       missingContextFields: ["company.id"],
       ruleEvaluationResults: [false],
     });
   });
 
   it("fails evaluation and includes key in missing keys when rollout attribute is missing from context", async () => {
-    const myfeature = {
-      key: "myfeature",
-      targeting: {
-        rules: [
-          {
-            filter: {
-              type: "rolloutPercentage" as const,
-              key: "myfeature",
-              partialRolloutAttribute: "happening.id",
-              partialRolloutThreshold: 50000,
-            },
+    const res = evaluateFeatureRules({
+      featureKey: "myfeature",
+      rules: [
+        {
+          value: 123,
+          filter: {
+            type: "rolloutPercentage" as const,
+            key: "myfeature",
+            partialRolloutAttribute: "happening.id",
+            partialRolloutThreshold: 50000,
           },
-        ],
-      },
-    };
-    const res = evaluateTargeting({
-      feature: myfeature,
+        },
+      ],
       context: {},
     });
+
     expect(res).toEqual({
-      feature: myfeature,
+      featureKey: "myfeature",
       context: {},
-      value: false,
+      value: undefined,
       reason: "no matched rules",
       missingContextFields: ["happening.id"],
       ruleEvaluationResults: [false],
@@ -364,4 +357,245 @@ describe("rollout hash", () => {
       expect(res).toEqual(expected);
     });
   }
+});
+
+describe("flattenJSON", () => {
+  it("should handle an empty object correctly", () => {
+    const input = {};
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({});
+  });
+
+  it("should flatten a simple object", () => {
+    const input = {
+      a: {
+        b: "value",
+      },
+    };
+
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({
+      "a.b": "value",
+    });
+  });
+
+  it("should flatten nested objects", () => {
+    const input = {
+      a: {
+        b: {
+          c: {
+            d: "value",
+          },
+        },
+      },
+    };
+
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({
+      "a.b.c.d": "value",
+    });
+  });
+
+  it("should handle mixed data types", () => {
+    const input = {
+      a: {
+        b: "string",
+        c: 123,
+        d: true,
+      },
+    };
+
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({
+      "a.b": "string",
+      "a.c": 123,
+      "a.d": true,
+    });
+  });
+
+  it("should flatten arrays", () => {
+    const input = {
+      a: ["value1", "value2", "value3"],
+    };
+
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({
+      "a.0": "value1",
+      "a.1": "value2",
+      "a.2": "value3",
+    });
+  });
+
+  it("should handle empty arrays", () => {
+    const input = {
+      a: [],
+    };
+
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({
+      a: [],
+    });
+  });
+
+  it("should correctly flatten mixed structures involving arrays and objects", () => {
+    const input = {
+      a: {
+        b: ["value1", { nested: "value2" }, "value3"],
+      },
+    };
+
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({
+      "a.b.0": "value1",
+      "a.b.1.nested": "value2",
+      "a.b.2": "value3",
+    });
+  });
+
+  it("should flatten deeply nested objects", () => {
+    const input = {
+      level1: {
+        level2: {
+          level3: {
+            key: "value",
+            anotherKey: "anotherValue",
+          },
+        },
+        singleKey: "test",
+      },
+    };
+
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({
+      "level1.level2.level3.key": "value",
+      "level1.level2.level3.anotherKey": "anotherValue",
+      "level1.singleKey": "test",
+    });
+  });
+
+  it("should handle objects with empty values", () => {
+    const input = {
+      a: {
+        b: "",
+      },
+    };
+
+    const output = flattenJSON(input);
+
+    expect(output).toEqual({
+      "a.b": "",
+    });
+  });
+});
+
+describe("unflattenJSON", () => {
+  it("should handle an empty object correctly", () => {
+    const input = {};
+    const output = unflattenJSON(input);
+
+    expect(output).toEqual({});
+  });
+
+  it("should convert a flat object with one level deep keys to a nested object", () => {
+    const input = {
+      "a.b.c": "value",
+      "x.y": "anotherValue",
+    };
+
+    const output = unflattenJSON(input);
+
+    expect(output).toEqual({
+      a: {
+        b: { c: "value" },
+      },
+      x: {
+        y: "anotherValue",
+      },
+    });
+  });
+
+  it("should not handle arrays properly", () => {
+    const input = {
+      "arr.0": "first",
+      "arr.1": "second",
+      "arr.2": "third",
+    };
+
+    const output = unflattenJSON(input);
+
+    expect(output).toEqual({
+      arr: {
+        "0": "first",
+        "1": "second",
+        "2": "third",
+      },
+    });
+  });
+
+  it("should handle mixed data types in flat JSON", () => {
+    const input = {
+      "a.b": "string",
+      "a.c": 123,
+      "a.d": true,
+    };
+
+    const output = unflattenJSON(input);
+
+    expect(output).toEqual({
+      a: {
+        b: "string",
+        c: 123,
+        d: true,
+      },
+    });
+  });
+
+  it("should correctly handle scenarios with overlapping keys", () => {
+    const input = {
+      "a.b": "value1",
+      "a.b.c": "value2",
+    };
+
+    expect(() => unflattenJSON(input)).toThrow("overlapping keys");
+  });
+
+  it("should unflatten nested objects correctly", () => {
+    const input = {
+      "level1.level2.level3": "deepValue",
+      "level1.level2.key": 10,
+      "level1.singleKey": "test",
+    };
+
+    const output = unflattenJSON(input);
+
+    expect(output).toEqual({
+      level1: {
+        level2: {
+          level3: "deepValue",
+          key: 10,
+        },
+        singleKey: "test",
+      },
+    });
+  });
+
+  it("should handle a scenario where a key is an empty string", () => {
+    const input = {
+      "": "rootValue",
+    };
+
+    const output = unflattenJSON(input);
+
+    expect(output).toEqual({
+      "": "rootValue",
+    });
+  });
 });

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -44,6 +44,6 @@
     "vitest": "~1.6.0"
   },
   "dependencies": {
-    "@bucketco/flag-evaluation": "~1.0.0"
+    "@bucketco/flag-evaluation": "~0.1.0"
   }
 }

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -44,6 +44,6 @@
     "vitest": "~1.6.0"
   },
   "dependencies": {
-    "@bucketco/flag-evaluation": "~0.0.7"
+    "@bucketco/flag-evaluation": "~1.0.0"
   }
 }

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -1,4 +1,4 @@
-import { FeatureData } from "@bucketco/flag-evaluation";
+import { RuleFilter } from "@bucketco/flag-evaluation";
 
 /**
  * Describes the meta context associated with tracking.
@@ -122,11 +122,24 @@ export type FeatureOverrides = Partial<Record<keyof TypedFeatures, boolean>>;
 export type FeatureOverridesFn = (context: Context) => FeatureOverrides;
 
 /**
+ * Describes a specific feature in the API response
+ */
+type FeatureAPIResponse = {
+  key: string;
+  targeting: {
+    version: number;
+    rules: {
+      filter: RuleFilter;
+    }[];
+  };
+};
+
+/**
  * Describes the response of the features endpoint
  */
 export type FeaturesAPIResponse = {
   /** The feature definitions */
-  features: (FeatureData & { targeting: { version: number } })[];
+  features: FeatureAPIResponse[];
 };
 
 export type EvaluatedFeaturesAPIResponse = {

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -10,9 +10,9 @@ import {
   vi,
 } from "vitest";
 
-import { evaluateTargeting } from "@bucketco/flag-evaluation";
+import { evaluateFeatureRules } from "@bucketco/flag-evaluation";
 
-import { BoundBucketClient, BucketClient } from "../src/client";
+import { BoundBucketClient, BucketClient } from "../src";
 import {
   API_HOST,
   BATCH_INTERVAL_MS,
@@ -32,7 +32,7 @@ vi.mock("@bucketco/flag-evaluation", async (importOriginal) => {
   const original = (await importOriginal()) as any;
   return {
     ...original,
-    evaluateTargeting: vi.fn(),
+    evaluateFeatureRules: vi.fn(),
   };
 });
 
@@ -892,18 +892,15 @@ describe("BucketClient", () => {
 
       client = new BucketClient(validOptions);
 
-      vi.mocked(evaluateTargeting).mockImplementation(
-        ({ feature, context }) => {
+      vi.mocked(evaluateFeatureRules).mockImplementation(
+        ({ featureKey, context }) => {
           const evalFeature = evaluatedFeatures.find(
-            (f) => f.feature.key === feature.key,
-          )!;
-          const featureDef = featureDefinitions.features.find(
-            (f) => f.key === feature.key,
+            (f) => f.feature.key === featureKey,
           )!;
 
           return {
             value: evalFeature.value,
-            feature: featureDef,
+            featureKey,
             context: context,
             ruleEvaluationResults: evalFeature.ruleEvaluationResults,
             missingContextFields: evalFeature.missingContextFields,
@@ -1126,18 +1123,15 @@ describe("BucketClient", () => {
 
       client = new BucketClient(validOptions);
 
-      vi.mocked(evaluateTargeting).mockImplementation(
-        ({ feature, context }) => {
+      vi.mocked(evaluateFeatureRules).mockImplementation(
+        ({ featureKey, context }) => {
           const evalFeature = evaluatedFeatures.find(
-            (f) => f.feature.key === feature.key,
-          )!;
-          const featureDef = featureDefinitions.features.find(
-            (f) => f.key === feature.key,
+            (f) => f.feature.key === featureKey,
           )!;
 
           return {
             value: evalFeature.value,
-            feature: featureDef,
+            featureKey,
             context: context,
             ruleEvaluationResults: evalFeature.ruleEvaluationResults,
             missingContextFields: evalFeature.missingContextFields,
@@ -1178,7 +1172,7 @@ describe("BucketClient", () => {
 
       await client.flush();
 
-      expect(evaluateTargeting).toHaveBeenCalledTimes(2);
+      expect(evaluateFeatureRules).toHaveBeenCalledTimes(2);
       expect(httpClient.post).toHaveBeenCalledTimes(1);
 
       expect(httpClient.post).toHaveBeenCalledWith(
@@ -1265,7 +1259,7 @@ describe("BucketClient", () => {
 
       await client.flush();
 
-      expect(evaluateTargeting).toHaveBeenCalledTimes(2);
+      expect(evaluateFeatureRules).toHaveBeenCalledTimes(2);
       expect(httpClient.post).toHaveBeenCalledTimes(1);
 
       expect(httpClient.post).toHaveBeenCalledWith(
@@ -1335,7 +1329,7 @@ describe("BucketClient", () => {
 
       await client.flush();
 
-      expect(evaluateTargeting).toHaveBeenCalledTimes(2);
+      expect(evaluateFeatureRules).toHaveBeenCalledTimes(2);
       expect(httpClient.post).toHaveBeenCalledTimes(1);
 
       expect(httpClient.post).toHaveBeenCalledWith(
@@ -1405,7 +1399,7 @@ describe("BucketClient", () => {
 
       await client.flush();
 
-      expect(evaluateTargeting).toHaveBeenCalledTimes(2);
+      expect(evaluateFeatureRules).toHaveBeenCalledTimes(2);
       expect(httpClient.post).not.toHaveBeenCalled();
     });
 
@@ -1415,7 +1409,7 @@ describe("BucketClient", () => {
 
       await client.flush();
 
-      expect(evaluateTargeting).toHaveBeenCalledTimes(2);
+      expect(evaluateFeatureRules).toHaveBeenCalledTimes(2);
       expect(httpClient.post).toHaveBeenCalledTimes(1);
 
       expect(httpClient.post).toHaveBeenCalledWith(
@@ -1654,8 +1648,8 @@ describe("BucketClient", () => {
       await client.initialize();
       const context = { user, company, other: otherContext };
 
-      const prestineResults = client.getFeatures(context);
-      expect(prestineResults).toStrictEqual({
+      const pristineResults = client.getFeatures(context);
+      expect(pristineResults).toStrictEqual({
         feature1: {
           key: "feature1",
           isEnabled: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,7 +943,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bucketco/flag-evaluation@npm:~0.0.7, @bucketco/flag-evaluation@workspace:packages/flag-evaluation":
+"@bucketco/flag-evaluation@npm:~1.0.0, @bucketco/flag-evaluation@workspace:packages/flag-evaluation":
   version: 0.0.0-use.local
   resolution: "@bucketco/flag-evaluation@workspace:packages/flag-evaluation"
   dependencies:
@@ -964,7 +964,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:~7.24.7"
     "@bucketco/eslint-config": "npm:~0.0.2"
-    "@bucketco/flag-evaluation": "npm:~0.0.7"
+    "@bucketco/flag-evaluation": "npm:~1.0.0"
     "@bucketco/tsconfig": "npm:~0.0.2"
     "@types/node": "npm:~20.14.9"
     "@vitest/coverage-v8": "npm:~1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,7 +955,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bucketco/flag-evaluation@npm:~1.0.0, @bucketco/flag-evaluation@workspace:packages/flag-evaluation":
+"@bucketco/flag-evaluation@npm:~0.1.0, @bucketco/flag-evaluation@workspace:packages/flag-evaluation":
   version: 0.0.0-use.local
   resolution: "@bucketco/flag-evaluation@workspace:packages/flag-evaluation"
   dependencies:
@@ -976,7 +976,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:~7.24.7"
     "@bucketco/eslint-config": "npm:~0.0.2"
-    "@bucketco/flag-evaluation": "npm:~1.0.0"
+    "@bucketco/flag-evaluation": "npm:~0.1.0"
     "@bucketco/tsconfig": "npm:~0.0.2"
     "@types/node": "npm:~20.14.9"
     "@vitest/coverage-v8": "npm:~1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,7 +894,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bucketco/browser-sdk@npm:2.4.1, @bucketco/browser-sdk@workspace:packages/browser-sdk":
+"@bucketco/browser-sdk@npm:2.4.1":
+  version: 2.4.1
+  resolution: "@bucketco/browser-sdk@npm:2.4.1"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.6.8"
+    canonical-json: "npm:^0.0.4"
+    js-cookie: "npm:^3.0.5"
+    preact: "npm:^10.22.1"
+  checksum: 10c0/fc29e3d52c713cf23bc7180dc30ca771b3a7ecf193d0d6572e6a66f794d914b4cb2a4252014f55a74ddff1880ac2e91f3718fbb2d04ea9b4e5c1a50e55ebb7ee
+  languageName: node
+  linkType: hard
+
+"@bucketco/browser-sdk@workspace:packages/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/browser-sdk@workspace:packages/browser-sdk"
   dependencies:


### PR DESCRIPTION
Updated the Node and Browser SDKs to utilize the new `evaluateFeatureRules` method from `@bucketco/flag-evaluation@~1.0.0`. This enhances the clarity and compatibility of feature evaluation logic. Adjusted related test cases and bumped package version to 1.4.4.