### PR TITLE
Introduce methods to update context after intialization

### DIFF
--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -160,6 +160,23 @@ you can customize it as you wish.
 bucketClient.track("huddle", { voiceHuddle: true });
 ```
 
+### Updating user/company/other context
+
+Attributes given for the user/company/other context in the BucketClient constructor can be updated for use in feature targeting evaluation with the `updateUser()`, `updateCompany()` and `updateOtherContext()` methods.
+They return a promise which resolves once the features have been re-evaluated follow the update of the attributes.
+
+The following shows how to let users self-opt-in for a new feature. The feature must have the rule `voiceHuddleOptIn IS true` set in the Bucket UI.
+
+```ts
+// toggle opt-in for the voiceHuddle feature:
+const { isEnabled } = bucketClient.getFeature("voiceHuddle");
+// this toggles the feature on/off. The promise returns once feature targeting has been
+// re-evaluated.
+await bucketClient.updateUser({ voiceHuddleOptIn: (!isEnabled).toString() });
+```
+
+Note that user/company attributes are also stored remotely on the Bucket servers and will automatically be used to evaluate feature targeting if the page is refreshed.
+
 ### Qualitative feedback
 
 Bucket can collect qualitative feedback from your users in the form of a [Customer Satisfaction Score](https://en.wikipedia.org/wiki/Customer_satisfaction) and a comment.

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -193,7 +193,7 @@ export class BucketClient {
   /**
    * Update the user context.
    * @description Performs a shallow merge with the existing user context.
-   * Updates to the user ID will be ignored.
+   * Attempting to update the user ID will log a warning and be ignored.
    *
    * @param user
    */
@@ -217,7 +217,7 @@ export class BucketClient {
   /**
    * Update the company context.
    * Performs a shallow merge with the existing company context.
-   * Updates to the company ID will be ignored.
+   * Attempting to update the company ID will log a warning and be ignored.
    *
    * @param company
    */

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -242,6 +242,87 @@ export class BucketClient {
   }
 
   /**
+   * Update the user context.
+   * @description Performs a shallow merge with the existing user context.
+   * Updates to the user ID will be ignored.
+   *
+   * @param user
+   */
+  public async updateUser(user: {
+    [key: string]: string | number | undefined;
+  }) {
+    if (user.id && user.id !== this.context.user?.id) {
+      this.logger.warn(
+        "ignoring attempt to update the user ID. Re-initialize the BucketClient with a new user ID instead.",
+      );
+      return;
+    }
+
+    this.context.user = {
+      ...this.context.user,
+      ...user,
+      id: user.id ?? this.context.user?.id,
+    };
+    void this.user();
+    await this.featuresClient.setContext(this.context);
+  }
+
+  /**
+   * Update the company context.
+   * Performs a shallow merge with the existing company context.
+   * Updates to the company ID will be ignored.
+   *
+   * @param company
+   */
+  public async updateCompany(company: {
+    [key: string]: string | number | undefined;
+  }) {
+    if (company.id && company.id !== this.context.company?.id) {
+      this.logger.warn(
+        "ignoring attempt to update the company ID. Re-initialize the BucketClient with a new company ID instead.",
+      );
+      return;
+    }
+    this.context.company = {
+      ...this.context.company,
+      ...company,
+      id: company.id ?? this.context.company?.id,
+    };
+    void this.company();
+    await this.featuresClient.setContext(this.context);
+  }
+
+  /**
+   * Update the company context.
+   * Performs a shallow merge with the existing company context.
+   * Updates to the company ID will be ignored.
+   *
+   * @param company
+   */
+  public async updateOtherContext(otherContext: {
+    [key: string]: string | number | undefined;
+  }) {
+    this.context.otherContext = {
+      ...this.context.otherContext,
+      ...otherContext,
+    };
+    await this.featuresClient.setContext(this.context);
+  }
+
+  /**
+   * Register a callback to be called when the features are updated.
+   * Features are not guaranteed to have actually changed when the callback is called.
+   *
+   * Calling `client.stop()` will remove all listeners added here.
+   *
+   * @param callback this will be called when the features are updated.
+   * @param options passed as-is to addEventListener
+   */
+  public onFeaturesUpdated(cb: () => void) {
+    return this.featuresClient.onUpdated(cb);
+  }
+
+  /**
    * Track an event in Bucket.
    *
    * @param eventName The name of the event
@@ -414,7 +495,10 @@ export class BucketClient {
   }
 
   /**
-   * Stop the SDK. This will stop any automated feedback surveys.
+   * Stop the SDK.
+   * This will stop any automated feedback surveys.
+   * It will also stop the features client, including removing
+   * any onFeaturesUpdated listeners.
    *
    **/
   async stop() {
@@ -423,5 +507,7 @@ export class BucketClient {
       await this.autoFeedbackInit;
       this.autoFeedback.stop();
     }
+
+    this.featuresClient.stop();
   }
 }

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -197,9 +197,7 @@ export class BucketClient {
    *
    * @param user
    */
-  public async updateUser(user: {
-    [key: string]: string | number | undefined;
-  }) {
+  async updateUser(user: { [key: string]: string | number | undefined }) {
     if (user.id && user.id !== this.context.user?.id) {
       this.logger.warn(
         "ignoring attempt to update the user ID. Re-initialize the BucketClient with a new user ID instead.",
@@ -223,9 +221,7 @@ export class BucketClient {
    *
    * @param company
    */
-  public async updateCompany(company: {
-    [key: string]: string | number | undefined;
-  }) {
+  async updateCompany(company: { [key: string]: string | number | undefined }) {
     if (company.id && company.id !== this.context.company?.id) {
       this.logger.warn(
         "ignoring attempt to update the company ID. Re-initialize the BucketClient with a new company ID instead.",
@@ -248,7 +244,7 @@ export class BucketClient {
    *
    * @param company
    */
-  public async updateOtherContext(otherContext: {
+  async updateOtherContext(otherContext: {
     [key: string]: string | number | undefined;
   }) {
     this.context.otherContext = {
@@ -267,7 +263,7 @@ export class BucketClient {
    * @param callback this will be called when the features are updated.
    * @param options passed as-is to addEventListener
    */
-  public onFeaturesUpdated(cb: () => void) {
+  onFeaturesUpdated(cb: () => void) {
     return this.featuresClient.onUpdated(cb);
   }
 

--- a/packages/browser-sdk/src/context.ts
+++ b/packages/browser-sdk/src/context.ts
@@ -14,5 +14,5 @@ export interface UserContext {
 export interface BucketContext {
   company?: CompanyContext;
   user?: UserContext;
-  otherContext?: Record<string, string | number>;
+  otherContext?: Record<string, string | number | undefined>;
 }

--- a/packages/browser-sdk/src/feature/features.ts
+++ b/packages/browser-sdk/src/feature/features.ts
@@ -15,6 +15,8 @@ export type RawFeature = {
   targetingVersion?: number;
 };
 
+const FEATURES_UPDATED_EVENT = "features-updated";
+
 export type RawFeatures = Record<string, RawFeature | undefined>;
 
 export type FeaturesOptions = {
@@ -109,6 +111,12 @@ export interface CheckEvent {
   version?: number;
 }
 
+type context = {
+  user?: Record<string, any>;
+  company?: Record<string, any>;
+  other?: Record<string, any>;
+};
+
 export const FEATURES_EXPIRE_MS = 30 * 24 * 60 * 60 * 1000; // expire entirely after 30 days
 
 const localStorageCacheKey = `__bucket_features`;
@@ -120,13 +128,12 @@ export class FeaturesClient {
   private rateLimiter: RateLimiter;
   private logger: Logger;
 
+  private eventTarget = new EventTarget();
+  private abortController: AbortController = new AbortController();
+
   constructor(
     private httpClient: HttpClient,
-    private context: {
-      user?: Record<string, any>;
-      company?: Record<string, any>;
-      other?: Record<string, any>;
-    },
+    private context: context,
     logger: Logger,
     options?: FeaturesOptions & {
       cache?: FeatureCache;
@@ -156,8 +163,42 @@ export class FeaturesClient {
     this.setFeatures(features);
   }
 
+  async setContext(context: context) {
+    this.context = context;
+    await this.initialize();
+  }
+
   private setFeatures(features: RawFeatures) {
     this.features = features;
+    this.eventTarget.dispatchEvent(new Event(FEATURES_UPDATED_EVENT));
+  }
+
+  /**
+   * Stop the client.
+   */
+  public stop() {
+    this.abortController.abort();
+  }
+
+  /**
+   * Register a callback to be called when the features are updated.
+   * Features are not guaranteed to have actually changed when the callback is called.
+   *
+   * @param callback this will be called when the features are updated.
+   * @param options passed as-is to addEventListener, except the abort signal is not supported.
+   * @returns a function that can be called to remove the listener
+   */
+  onUpdated(callback: () => void, options?: AddEventListenerOptions | boolean) {
+    this.eventTarget.addEventListener(FEATURES_UPDATED_EVENT, callback, {
+      signal: this.abortController.signal,
+    });
+    return () => {
+      this.eventTarget.removeEventListener(
+        FEATURES_UPDATED_EVENT,
+        callback,
+        options,
+      );
+    };
   }
 
   getFeatures(): RawFeatures {

--- a/packages/browser-sdk/test/client.test.ts
+++ b/packages/browser-sdk/test/client.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BucketClient } from "../src/client";
+import { FeaturesClient } from "../src/feature/features";
+import { HttpClient } from "../src/httpClient";
+
+describe("BucketClient", () => {
+  let client: BucketClient;
+  const httpClientPost = vi.spyOn(HttpClient.prototype as any, "post");
+
+  const featureClientSetContext = vi.spyOn(
+    FeaturesClient.prototype,
+    "setContext",
+  );
+
+  beforeEach(() => {
+    client = new BucketClient({
+      publishableKey: "test-key",
+      user: { id: "user1" },
+      company: { id: "company1" },
+    });
+  });
+
+  describe("updateUser", () => {
+    it("should update the user context", async () => {
+      // and send new user data and trigger feature update
+      const updatedUser = { name: "New User" };
+
+      await client.updateUser(updatedUser);
+
+      expect(client["context"].user).toEqual({ id: "user1", ...updatedUser });
+      expect(httpClientPost).toHaveBeenCalledWith({
+        path: "/user",
+        body: {
+          userId: "user1",
+          attributes: { name: updatedUser.name },
+        },
+      });
+      expect(featureClientSetContext).toHaveBeenCalledWith(client["context"]);
+    });
+  });
+
+  describe("updateCompany", () => {
+    it("should update the company context", async () => {
+      // send new company data and trigger feature update
+      const updatedCompany = { name: "New Company" };
+
+      await client.updateCompany(updatedCompany);
+
+      expect(client["context"].company).toEqual({
+        id: "company1",
+        ...updatedCompany,
+      });
+      expect(httpClientPost).toHaveBeenCalledWith({
+        path: "/company",
+        body: {
+          userId: "user1",
+          companyId: "company1",
+          attributes: { name: updatedCompany.name },
+        },
+      });
+      expect(featureClientSetContext).toHaveBeenCalledWith(client["context"]);
+    });
+  });
+});

--- a/packages/browser-sdk/test/features.test.ts
+++ b/packages/browser-sdk/test/features.test.ts
@@ -58,9 +58,16 @@ describe("FeaturesClient unit tests", () => {
   test("fetches features", async () => {
     const { newFeaturesClient, httpClient } = featuresClientFactory();
     const featuresClient = newFeaturesClient();
+
+    let updated = false;
+    featuresClient.onUpdated(() => {
+      updated = true;
+    });
+
     await featuresClient.initialize();
     expect(featuresClient.getFeatures()).toEqual(featuresResult);
 
+    expect(updated).toBe(true);
     expect(httpClient.get).toBeCalledTimes(1);
     const calls = vi.mocked(httpClient.get).mock.calls.at(0);
     const { params, path, timeoutMs } = calls![0];

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -190,7 +190,28 @@ sendFeedback({
 });
 ```
 
-See https://github.com/bucketco/bucket-javascript-sdk/blob/main/packages/browser-sdk/FEEDBACK.md#manual-feedback-collection for more information on `sendFeedback`
+### `useUpdateUser()`, `useUpdateCompany()` and `useUpdateOtherContext()`
+
+`useUpdateUser()`, `useUpdateCompany()` and `useUpdateOtherContext()` all return
+a function that lets you update the attributes for the currently set user/company.
+
+Updates made to user/company are stored remotely and are used automatically
+for evaluating feature targeting in the future, while "other" context is only
+used in the current session.
+
+This is only useful for updating attributes for the already set user/company.
+If you want to change the user.id or company.id, you need to update the props
+given the `BucketProvider` instead.
+
+```ts
+import { useUpdateUser } from "@bucketco/react-sdk";
+
+const updateUser = useUpdateUser();
+
+updateUser({
+  huddlesOptIn: "true",
+});
+```
 
 # Content Security Policy (CSP)
 

--- a/packages/react-sdk/dev/plain/app.tsx
+++ b/packages/react-sdk/dev/plain/app.tsx
@@ -17,7 +17,8 @@ declare module "../../src" {
   }
 }
 
-const publishableKey = import.meta.env.PUBLISHABLE_KEY || "";
+const publishableKey = import.meta.env.VITE_PUBLISHABLE_KEY || "";
+const host = import.meta.env.VITE_BUCKET_HOST || "http://localhost:3000";
 
 function HuddleFeature() {
   // Type safe feature
@@ -59,7 +60,10 @@ function UpdateContext() {
   return (
     <div>
       <h2>Update context</h2>
-
+      <div>
+        Update the context by editing the textarea. User/company IDs cannot be
+        changed here.
+      </div>
       <table>
         <tbody>
           <tr>
@@ -180,6 +184,13 @@ function FeatureOptIn() {
   return (
     <div>
       <h2>Feature opt-in</h2>
+      <div style={{ display: "flex", flexFlow: "column" }}></div>
+      <div>
+        Create a <code>huddle</code> feature and set a rule:{" "}
+        <code>optInHuddles IS TRUE</code>. Hit the checkbox below to opt-in/out
+        of the feature.
+      </div>
+
       <label htmlFor="huddlesOptIn">Opt-in to Huddle feature</label>
       <input
         disabled={sendingUpdate}
@@ -209,6 +220,7 @@ export function App() {
       company={initialCompany}
       user={initialUser}
       otherContext={initialOtherContext}
+      host={host}
     >
       <Demos />
       {}

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@bucketco/browser-sdk": "2.4.1",
+    "@bucketco/browser-sdk": "2.4.2",
     "canonical-json": "^0.0.4"
   },
   "peerDependencies": {

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -23,6 +23,9 @@ import {
   useRequestFeedback,
   useSendFeedback,
   useTrack,
+  useUpdateCompany,
+  useUpdateOtherContext,
+  useUpdateUser,
 } from "../src";
 
 const events: string[] = [];
@@ -144,8 +147,11 @@ beforeEach(() => {
 
 describe("<BucketProvider />", () => {
   test("calls initialize", () => {
+    const onFeaturesUpdated = vi.fn();
+
     const newBucketClient = vi.fn().mockReturnValue({
       initialize: vi.fn().mockResolvedValue(undefined),
+      onFeaturesUpdated,
     });
 
     const provider = getProvider({
@@ -184,6 +190,8 @@ describe("<BucketProvider />", () => {
         sdkVersion: `react-sdk/${version}`,
       },
     ]);
+
+    expect(onFeaturesUpdated).toBeTruthy();
   });
 
   test("only calls init once with the same args", () => {
@@ -197,23 +205,6 @@ describe("<BucketProvider />", () => {
 
     expect(initialize).toHaveBeenCalledOnce();
     expect(BucketClient.prototype.stop).not.toHaveBeenCalledOnce();
-  });
-
-  test("calls stop on unmount", () => {
-    const node = getProvider();
-    const initialize = vi.spyOn(BucketClient.prototype, "initialize");
-
-    const x = render(node);
-    x.rerender(node);
-    x.rerender(node);
-    x.rerender(node);
-
-    expect(initialize).toHaveBeenCalledOnce();
-    expect(BucketClient.prototype.stop).not.toHaveBeenCalledOnce();
-
-    x.unmount();
-
-    expect(BucketClient.prototype.stop).toHaveBeenCalledOnce();
   });
 });
 
@@ -306,6 +297,89 @@ describe("useRequestFeedback", () => {
         companyId: "456",
         featureId: "123",
         title: "Test question",
+      });
+    });
+
+    unmount();
+  });
+});
+
+describe("useUpdateUser", () => {
+  test("updates user", async () => {
+    const updateUser = vi
+      .spyOn(BucketClient.prototype, "updateUser")
+      .mockResolvedValue(undefined);
+
+    const { result: updateUserFn, unmount } = renderHook(
+      () => useUpdateUser(),
+      {
+        wrapper: ({ children }) => getProvider({ children }),
+      },
+    );
+
+    // todo: need this `waitFor` because useUpdateOtherContext
+    // runs before `client` is initialized and then the call gets
+    // lost.
+    await waitFor(async () => {
+      await updateUserFn.current({ optInHuddles: "true" });
+
+      expect(updateUser).toHaveBeenCalledWith({
+        optInHuddles: "true",
+      });
+    });
+
+    unmount();
+  });
+});
+
+describe("useUpdateCompany", () => {
+  test("updates company", async () => {
+    const updateCompany = vi
+      .spyOn(BucketClient.prototype, "updateCompany")
+      .mockResolvedValue(undefined);
+
+    const { result: updateCompanyFn, unmount } = renderHook(
+      () => useUpdateCompany(),
+      {
+        wrapper: ({ children }) => getProvider({ children }),
+      },
+    );
+
+    // todo: need this `waitFor` because useUpdateOtherContext
+    // runs before `client` is initialized and then the call gets
+    // lost.
+    await waitFor(async () => {
+      await updateCompanyFn.current({ optInHuddles: "true" });
+
+      expect(updateCompany).toHaveBeenCalledWith({
+        optInHuddles: "true",
+      });
+    });
+    unmount();
+  });
+});
+
+describe("useUpdateOtherContext", () => {
+  test("updates other context", async () => {
+    const updateOtherContext = vi
+      .spyOn(BucketClient.prototype, "updateOtherContext")
+      .mockResolvedValue(undefined);
+
+    const { result: updateOtherContextFn, unmount } = renderHook(
+      () => useUpdateOtherContext(),
+      {
+        wrapper: ({ children }) => getProvider({ children }),
+      },
+    );
+
+    // todo: need this `waitFor` because useUpdateOtherContext
+    // runs before `client` is initialized and then the call gets
+    // lost.
+    await waitFor(async () => {
+      await updateOtherContextFn.current({ optInHuddles: "true" });
+
+      expect(updateOtherContext).toHaveBeenCalledWith({
+        optInHuddles: "true",
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,19 +894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bucketco/browser-sdk@npm:2.4.1":
-  version: 2.4.1
-  resolution: "@bucketco/browser-sdk@npm:2.4.1"
-  dependencies:
-    "@floating-ui/dom": "npm:^1.6.8"
-    canonical-json: "npm:^0.0.4"
-    js-cookie: "npm:^3.0.5"
-    preact: "npm:^10.22.1"
-  checksum: 10c0/fc29e3d52c713cf23bc7180dc30ca771b3a7ecf193d0d6572e6a66f794d914b4cb2a4252014f55a74ddff1880ac2e91f3718fbb2d04ea9b4e5c1a50e55ebb7ee
-  languageName: node
-  linkType: hard
-
-"@bucketco/browser-sdk@workspace:packages/browser-sdk":
+"@bucketco/browser-sdk@npm:2.4.2, @bucketco/browser-sdk@workspace:packages/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/browser-sdk@workspace:packages/browser-sdk"
   dependencies:
@@ -1042,7 +1030,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bucketco/react-sdk@workspace:packages/react-sdk"
   dependencies:
-    "@bucketco/browser-sdk": "npm:2.4.1"
+    "@bucketco/browser-sdk": "npm:2.4.2"
     "@bucketco/eslint-config": "workspace:^"
     "@bucketco/tsconfig": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"


### PR DESCRIPTION
This introduced methods to let you update the user/company/other context after initialization. This lets you easily update data when it changes without needing to re-initialize etc. Useful for example to let users self opt-in to experimental features.

The PR also introduces some plumming needed to make sure that any changes that happen to feature targeting after you update the user/company/other is reflected, live, in the `useFeature` calls you have in your code. 