### PR TITLE
Update SDKs to use `apiBaseUrl` instead of `host`

### DIFF
--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/browser-sdk",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "packageManager": "yarn@4.1.1",
   "license": "MIT",
   "repository": {

--- a/packages/node-sdk/README.md
+++ b/packages/node-sdk/README.md
@@ -117,7 +117,7 @@ current working directory.
 | `secretKey`        | string                  | The secret key used for authentication with Bucket's servers.                                                                                                       | BUCKET_SECRET_KEY                                 |
 | `logLevel`         | string                  | The log level for the SDK (e.g., `"DEBUG"`, `"INFO"`, `"WARN"`, `"ERROR"`). Default: `INFO`                                                                         | BUCKET_LOG_LEVEL                                  |
 | `offline`          | boolean                 | Operate in offline mode. Default: `false`, except in tests it will default to `true` based off of the `TEST` env. var.                                              | BUCKET_OFFLINE                                    |
-| `host`             | string                  | The host URL for the Bucket servers.                                                                                                                                | BUCKET_HOST                                       |
+| `apiBaseUrl`       | string                  | The base API URL for the Bucket servers.                                                                                                                            | BUCKET_API_BASE_URL                               |
 | `featureOverrides` | Record<string, boolean> | An object specifying feature overrides for testing or local development. See [example/app.test.ts](example/app.test.ts) for how to use `featureOverrides` in tests. | BUCKET_FEATURES_ENABLED, BUCKET_FEATURES_DISABLED |
 | `configFile`       | string                  | Load this config file from disk. Default: `bucketConfig.json`                                                                                                       | BUCKET_CONFIG_FILE                                |
 
@@ -130,7 +130,7 @@ Note: BUCKET_FEATURES_ENABLED, BUCKET_FEATURES_DISABLED are comma separated list
   "secretKey": "...",
   "logLevel": "warn",
   "offline": true,
-  "host": "https://proxy.slick-demo.com",
+  "apiBaseUrl": "https://proxy.slick-demo.com",
   "featureOverrides": {
     "huddles": true,
     "voiceChat": false

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -5,7 +5,7 @@ import { evaluateFeatureRules, flattenJSON } from "@bucketco/flag-evaluation";
 import BatchBuffer from "./batch-buffer";
 import cache from "./cache";
 import {
-  API_HOST,
+  API_BASE_URL,
   BUCKET_LOG_PREFIX,
   FEATURE_EVENT_RATE_LIMITER_WINDOW_SIZE_MS,
   FEATURES_REFETCH_MS,
@@ -99,7 +99,7 @@ interface ContextWithTracking extends Context {
 export class BucketClient {
   private _config: {
     logger?: Logger;
-    host: string;
+    apiBaseUrl: string;
     httpClient: HttpClient;
     refetchInterval: number;
     staleWarningInterval: number;
@@ -133,6 +133,12 @@ export class BucketClient {
       options.host === undefined ||
         (typeof options.host === "string" && options.host.length > 0),
       "host must be a string",
+    );
+    ok(
+      options.apiBaseUrl === undefined ||
+        (typeof options.apiBaseUrl === "string" &&
+          options.apiBaseUrl.length > 0),
+      "apiBaseUrl must be a string",
     );
     ok(
       options.logger === undefined || isObject(options.logger),
@@ -199,7 +205,7 @@ export class BucketClient {
     this._config = {
       logger,
       offline,
-      host: config.host || API_HOST,
+      apiBaseUrl: (config.apiBaseUrl ?? config.host) || API_BASE_URL,
       headers: {
         "Content-Type": "application/json",
         [SDK_VERSION_HEADER_NAME]: SDK_VERSION,
@@ -220,6 +226,10 @@ export class BucketClient {
           ? config.featureOverrides
           : () => config.featureOverrides,
     };
+
+    if (!new URL(this._config.apiBaseUrl).pathname.endsWith("/")) {
+      this._config.apiBaseUrl += "/";
+    }
   }
 
   /**
@@ -504,6 +514,15 @@ export class BucketClient {
     return features[key];
   }
 
+  private buildUrl(path: string) {
+    if (path.startsWith("/")) {
+      path = path.slice(1);
+    }
+
+    const url = new URL(path, this._config.apiBaseUrl);
+    return url.toString();
+  }
+
   /**
    * Sends a POST request to the specified path.
    *
@@ -516,7 +535,7 @@ export class BucketClient {
     ok(typeof path === "string" && path.length > 0, "path must be a string");
     ok(typeof body === "object", "body must be an object");
 
-    const url = `${this._config.host}/${path}`;
+    const url = this.buildUrl(path);
     try {
       const response = await this._config.httpClient.post<
         TBody,
@@ -552,7 +571,7 @@ export class BucketClient {
     ok(typeof path === "string" && path.length > 0, "path must be a string");
 
     try {
-      const url = `${this._config.host}/${path}`;
+      const url = this.buildUrl(path);
       const response = await this._config.httpClient.get<
         TResponse & { success: boolean }
       >(url, this._config.headers);

--- a/packages/node-sdk/src/config.ts
+++ b/packages/node-sdk/src/config.ts
@@ -5,7 +5,7 @@ import { version } from "../package.json";
 import { LOG_LEVELS } from "./types";
 import { ok } from "./utils";
 
-export const API_HOST = "https://front.bucket.co";
+export const API_BASE_URL = "https://front.bucket.co";
 export const SDK_VERSION_HEADER_NAME = "bucket-sdk-version";
 export const SDK_VERSION = `node-sdk/${version}`;
 export const API_TIMEOUT_MS = 5000;
@@ -42,10 +42,15 @@ function loadConfigFile(file: string) {
   const config = JSON.parse(configJson);
 
   ok(typeof config === "object", "config must be an object");
-  const { secretKey, logLevel, offline, host } = config;
+  const { secretKey, logLevel, offline, host, apiBaseUrl } = config;
+
   ok(
     typeof secretKey === "undefined" || typeof secretKey === "string",
     "secret must be a string",
+  );
+  ok(
+    typeof apiBaseUrl === "undefined" || typeof apiBaseUrl === "string",
+    "apiBaseUrl must be a string",
   );
   ok(
     typeof logLevel === "undefined" ||
@@ -62,7 +67,7 @@ function loadConfigFile(file: string) {
     secretKey,
     logLevel,
     offline,
-    host,
+    apiBaseUrl: host ?? apiBaseUrl,
   };
 }
 
@@ -71,7 +76,7 @@ function loadEnvVars() {
   const enabledFeatures = process.env.BUCKET_FEATURES_ENABLED;
   const disabledFeatures = process.env.BUCKET_FEATURES_DISABLED;
   const logLevel = process.env.BUCKET_LOG_LEVEL;
-  const host = process.env.BUCKET_HOST;
+  const apiBaseUrl = process.env.BUCKET_API_BASE_URL ?? process.env.BUCKET_HOST;
   const offline =
     process.env.BUCKET_OFFLINE !== undefined
       ? ["true", "on"].includes(process.env.BUCKET_OFFLINE)
@@ -103,7 +108,7 @@ function loadEnvVars() {
     };
   }
 
-  return { secretKey, featureOverrides, logLevel, offline, host };
+  return { secretKey, featureOverrides, logLevel, offline, apiBaseUrl };
 }
 
 export function loadConfig(file?: string) {
@@ -118,7 +123,7 @@ export function loadConfig(file?: string) {
     secretKey: envConfig.secretKey || fileConfig?.secretKey,
     logLevel: envConfig.logLevel || fileConfig?.logLevel,
     offline: envConfig.offline ?? fileConfig?.offline,
-    host: envConfig.host ?? fileConfig?.host,
+    apiBaseUrl: envConfig.apiBaseUrl ?? fileConfig?.apiBaseUrl,
     featureOverrides: {
       ...fileConfig?.featureOverrides,
       ...envConfig.featureOverrides,

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -298,9 +298,15 @@ export type ClientOptions = {
   secretKey?: string;
 
   /**
-   * The host to send requests to (optional).
+   * @deprecated
+   * Use `apiBaseUrl` instead.
    **/
   host?: string;
+
+  /**
+   * The host to send requests to (optional).
+   **/
+  apiBaseUrl?: string;
 
   /**
    * The logger to use for logging (optional). Default is info level logging to console.

--- a/packages/node-sdk/test/config.test.ts
+++ b/packages/node-sdk/test/config.test.ts
@@ -13,7 +13,7 @@ describe("config tests", () => {
       },
       secretKey: "mySecretKey",
       offline: true,
-      host: "http://localhost:3000",
+      apiBaseUrl: "http://localhost:3000",
     });
   });
 
@@ -34,7 +34,7 @@ describe("config tests", () => {
       },
       secretKey: "mySecretKeyFromEnv",
       offline: true,
-      host: "http://localhost:4999",
+      apiBaseUrl: "http://localhost:4999",
     });
   });
 });

--- a/packages/node-sdk/test/testConfig.json
+++ b/packages/node-sdk/test/testConfig.json
@@ -5,5 +5,5 @@
   },
   "secretKey": "mySecretKey",
   "offline": true,
-  "host": "http://localhost:3000"
+  "apiBaseUrl": "http://localhost:3000"
 }

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/react-sdk",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@bucketco/browser-sdk": "2.4.1",
+    "@bucketco/browser-sdk": "2.5.0",
     "canonical-json": "^0.0.4"
   },
   "peerDependencies": {

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -53,8 +53,19 @@ export type BucketProps = BucketContext & {
   children?: ReactNode;
   loadingComponent?: ReactNode;
   feedback?: FeedbackOptions;
+  /**
+   * @deprecated
+   * Use `apiBaseUrl` instead.
+   */
   host?: string;
+  apiBaseUrl?: string;
+
+  /**
+   * @deprecated
+   * Use `sseBaseUrl` instead.
+   */
   sseHost?: string;
+  sseBaseUrl?: string;
   debug?: boolean;
   enableTracking?: boolean;
 
@@ -102,8 +113,11 @@ export function BucketProvider({
       user,
       company,
       otherContext,
+
       host: config.host,
+      apiBaseUrl: config.apiBaseUrl,
       sseHost: config.sseHost,
+      sseBaseUrl: config.sseBaseUrl,
 
       enableTracking: config.enableTracking,
 

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -150,8 +150,8 @@ describe("<BucketProvider />", () => {
 
     const provider = getProvider({
       publishableKey: "KEY",
-      host: "https://test.com",
-      sseHost: "https://test.com",
+      apiBaseUrl: "https://test.com",
+      sseBaseUrl: "https://test.com",
       company: { id: "123", name: "test" },
       user: { id: "456", name: "test" },
       otherContext: { test: "test" },
@@ -175,9 +175,11 @@ describe("<BucketProvider />", () => {
         otherContext: {
           test: "test",
         },
-        host: "https://test.com",
+        apiBaseUrl: "https://test.com",
+        host: undefined,
         logger: undefined,
-        sseHost: "https://test.com",
+        sseBaseUrl: "https://test.com",
+        sseHost: undefined,
         enableTracking: false,
         feedback: undefined,
         features: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,19 +894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bucketco/browser-sdk@npm:2.4.1":
-  version: 2.4.1
-  resolution: "@bucketco/browser-sdk@npm:2.4.1"
-  dependencies:
-    "@floating-ui/dom": "npm:^1.6.8"
-    canonical-json: "npm:^0.0.4"
-    js-cookie: "npm:^3.0.5"
-    preact: "npm:^10.22.1"
-  checksum: 10c0/fc29e3d52c713cf23bc7180dc30ca771b3a7ecf193d0d6572e6a66f794d914b4cb2a4252014f55a74ddff1880ac2e91f3718fbb2d04ea9b4e5c1a50e55ebb7ee
-  languageName: node
-  linkType: hard
-
-"@bucketco/browser-sdk@workspace:packages/browser-sdk":
+"@bucketco/browser-sdk@npm:2.5.0, @bucketco/browser-sdk@workspace:packages/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/browser-sdk@workspace:packages/browser-sdk"
   dependencies:
@@ -1042,7 +1030,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bucketco/react-sdk@workspace:packages/react-sdk"
   dependencies:
-    "@bucketco/browser-sdk": "npm:2.4.1"
+    "@bucketco/browser-sdk": "npm:2.5.0"
     "@bucketco/eslint-config": "workspace:^"
     "@bucketco/tsconfig": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"


### PR DESCRIPTION
Replaced the `host` property with `apiBaseUrl` across all SDKs for improved clarity and consistency. Updated tests, documentation, and implementation to reflect the change while marking `host` as deprecated for backward compatibility. Bumped versions to indicate non-breaking minor changes.