### PR TITLE
fix(node-sdk): ensure timers don't keep process alive

### DIFF
--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/src/batch-buffer.ts
+++ b/packages/node-sdk/src/batch-buffer.ts
@@ -54,7 +54,7 @@ export default class BatchBuffer<T> {
     if (this.buffer.length >= this.maxSize) {
       await this.flush();
     } else if (!this.timer) {
-      this.timer = setTimeout(() => this.flush(), this.intervalMs);
+      this.timer = setTimeout(() => this.flush(), this.intervalMs).unref();
     }
   }
 

--- a/packages/node-sdk/src/cache.ts
+++ b/packages/node-sdk/src/cache.ts
@@ -43,7 +43,7 @@ export default function cache<T>(
       logger?.error("failed to update cached value", e);
     } finally {
       refreshPromise = undefined;
-      timeoutId = setTimeout(update, ttl);
+      timeoutId = setTimeout(update, ttl).unref();
     }
   };
 

--- a/packages/node-sdk/src/rate-limiter.ts
+++ b/packages/node-sdk/src/rate-limiter.ts
@@ -43,7 +43,7 @@ export function newRateLimiter(windowSizeMs: number) {
 
   function isAllowed(key: string): boolean {
     clearIntervalId =
-      clearIntervalId || setInterval(() => clear(false), windowSizeMs);
+      clearIntervalId || setInterval(() => clear(false), windowSizeMs).unref();
 
     const now = Date.now();
 


### PR DESCRIPTION
Unable to write a test for this, but tested manually.