### PR TITLE
chore: auto-publish in "v*" branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v*
 
 jobs:
   release:


### PR DESCRIPTION
Since `main` has gone to 1.6-alpha, we need to start a separate branch for 1.5 series releases. This'll let us run the publish script from any branch that starts with `v` as in `v1.5`.