### PR TITLE
chore(browser-sdk,node-sdk): version 2.5.2

### DIFF
--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/browser-sdk",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "packageManager": "yarn@4.1.1",
   "license": "MIT",
   "repository": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/react-sdk",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@bucketco/browser-sdk": "2.5.1",
+    "@bucketco/browser-sdk": "2.5.2",
     "canonical-json": "^0.0.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,7 +894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bucketco/browser-sdk@npm:2.5.1, @bucketco/browser-sdk@workspace:packages/browser-sdk":
+"@bucketco/browser-sdk@npm:2.5.2, @bucketco/browser-sdk@workspace:packages/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/browser-sdk@workspace:packages/browser-sdk"
   dependencies:
@@ -1030,7 +1030,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bucketco/react-sdk@workspace:packages/react-sdk"
   dependencies:
-    "@bucketco/browser-sdk": "npm:2.5.1"
+    "@bucketco/browser-sdk": "npm:2.5.2"
     "@bucketco/eslint-config": "workspace:^"
     "@bucketco/tsconfig": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"


### PR DESCRIPTION
No-op release to fix NPM release tag in which latest points to a prerelease by mistake.
Node.js "latest" pointing to a prerelease was fixed here: https://github.com/bucketco/bucket-javascript-sdk/commit/579eb1c2d848e17fb127a6ee73c6529f6e470b89