### PR TITLE
feat(node-sdk): add configurable exit event flushing

### DIFF
--- a/packages/node-sdk/README.md
+++ b/packages/node-sdk/README.md
@@ -330,17 +330,6 @@ const client = new BucketClient({
 > If you are creating multiple client instances in your application, it's recommended to disable `flushOnExit`
 > to avoid potential conflicts during process shutdown. In such cases, you should implement your own flush handling.
 
-A naive example of manual flush handling:
-
-```typescript
-process.on("SIGINT", () => {
-  console.log("Flushing batch buffer...");
-  client.flush().then(() => {
-    process.exit(0);
-  });
-});
-```
-
 When you bind a client to a user/company, this data is matched against the
 targeting rules. To get accurate targeting, you must ensure that the user/company
 information provided is sufficient to match against the targeting rules you've

--- a/packages/node-sdk/README.md
+++ b/packages/node-sdk/README.md
@@ -315,7 +315,22 @@ the number of calls that are sent to Bucket's servers. During process shutdown,
 some messages could be waiting to be sent, and thus, would be discarded if the
 buffer is not flushed.
 
-A naive example:
+By default, the SDK automatically subscribes to process exit signals and attempts to flush
+any pending events. This behavior is controlled by the `flushOnExit` option in the client configuration:
+
+```typescript
+const client = new BucketClient({
+  batchOptions: {
+    flushOnExit: false, // disable automatic flushing on exit
+  },
+});
+```
+
+> [!NOTE]
+> If you are creating multiple client instances in your application, it's recommended to disable `flushOnExit`
+> to avoid potential conflicts during process shutdown. In such cases, you should implement your own flush handling.
+
+A naive example of manual flush handling:
 
 ```typescript
 process.on("SIGINT", () => {

--- a/packages/node-sdk/example/bucket.ts
+++ b/packages/node-sdk/example/bucket.ts
@@ -14,11 +14,6 @@ let featureOverrides = (context: Context): FeatureOverrides => {
   return { "delete-todos": true }; // feature keys checked at compile time
 };
 
-let host = undefined;
-if (process.env.BUCKET_HOST) {
-  host = process.env.BUCKET_HOST;
-}
-
 // Create a new BucketClient instance with the secret key and default features
 // The default features will be used if the user does not have any features set
 // Create a bucketConfig.json file to configure the client or set environment variables

--- a/packages/node-sdk/example/serve.ts
+++ b/packages/node-sdk/example/serve.ts
@@ -1,3 +1,5 @@
+import "dotenv/config";
+
 import bucket from "./bucket";
 import app from "./app";
 

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -14,6 +14,7 @@ import {
   SDK_VERSION_HEADER_NAME,
 } from "./config";
 import fetchClient from "./fetch-http-client";
+import { subscribe as triggerOnExit } from "./flusher";
 import { newRateLimiter } from "./rate-limiter";
 import type {
   EvaluatedFeaturesAPIResponse,
@@ -102,6 +103,7 @@ export class BucketClient {
     offline: boolean;
     configFile?: string;
   };
+
   private _initialize = once(async () => {
     if (!this._config.offline) {
       await this.getFeaturesCache().refresh();
@@ -216,6 +218,10 @@ export class BucketClient {
           ? config.featureOverrides
           : () => config.featureOverrides,
     };
+
+    if ((config.batchOptions?.flushOnExit ?? true) && !this._config.offline) {
+      triggerOnExit(this.flush);
+    }
 
     if (!new URL(this._config.apiBaseUrl).pathname.endsWith("/")) {
       this._config.apiBaseUrl += "/";
@@ -404,8 +410,14 @@ export class BucketClient {
    * @remarks
    * It is recommended to call this method when the application is shutting down to ensure all events are sent
    * before the process exits.
+   *
+   * This method is automatically called when the process exits if `batchOptions.flushOnExit` is `true` in the options (default).
    */
   public async flush() {
+    if (this._config.offline) {
+      return;
+    }
+
     await this._config.batchBuffer.flush();
   }
 

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -220,7 +220,7 @@ export class BucketClient {
     };
 
     if ((config.batchOptions?.flushOnExit ?? true) && !this._config.offline) {
-      triggerOnExit(this.flush);
+      triggerOnExit(() => this.flush());
     }
 
     if (!new URL(this._config.apiBaseUrl).pathname.endsWith("/")) {

--- a/packages/node-sdk/src/config.ts
+++ b/packages/node-sdk/src/config.ts
@@ -9,6 +9,7 @@ export const API_BASE_URL = "https://front.bucket.co";
 export const SDK_VERSION_HEADER_NAME = "bucket-sdk-version";
 export const SDK_VERSION = `node-sdk/${version}`;
 export const API_TIMEOUT_MS = 5000;
+export const END_FLUSH_TIMEOUT_MS = 5000;
 
 export const BUCKET_LOG_PREFIX = "[Bucket]";
 

--- a/packages/node-sdk/src/flusher.ts
+++ b/packages/node-sdk/src/flusher.ts
@@ -1,7 +1,7 @@
 import { constants } from "os";
 
 import { END_FLUSH_TIMEOUT_MS } from "./config";
-import { withTimeout, TimeoutError } from "./utils";
+import { TimeoutError, withTimeout } from "./utils";
 
 type Callback = () => Promise<void>;
 

--- a/packages/node-sdk/src/flusher.ts
+++ b/packages/node-sdk/src/flusher.ts
@@ -1,0 +1,64 @@
+import { constants } from "os";
+
+import { END_FLUSH_TIMEOUT_MS } from "./config";
+
+type Callback = () => Promise<void>;
+
+const killSignals = ["SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK"] as const;
+
+export function subscribe(
+  callback: Callback,
+  timeout: number = END_FLUSH_TIMEOUT_MS,
+) {
+  let state: boolean | undefined;
+
+  const wrappedCallback = async () => {
+    if (state !== undefined) {
+      return;
+    }
+
+    state = false;
+
+    try {
+      const result = await Promise.race([
+        new Promise((resolve) => setTimeout(() => resolve(true), timeout)),
+        callback(),
+      ]);
+
+      if (result === true) {
+        console.error(
+          "[Bucket SDK] Timeout while flushing events on process exit.",
+        );
+      }
+    } catch (error) {
+      console.error(
+        "[Bucket SDK] An error occurred while flushing events on process exit.",
+        error,
+      );
+    }
+
+    state = true;
+  };
+
+  killSignals.forEach((signal) => {
+    const hasListeners = process.listenerCount(signal) > 0;
+
+    if (hasListeners) {
+      process.prependListener(signal, wrappedCallback);
+    } else {
+      process.on(signal, async () => {
+        await wrappedCallback();
+        process.exit(0x100 + constants.signals[signal]);
+      });
+    }
+  });
+
+  process.on("beforeExit", wrappedCallback);
+  process.on("exit", () => {
+    if (!state) {
+      console.error(
+        "[Bucket SDK] Failed to finalize the flushing of events on process exit.",
+      );
+    }
+  });
+}

--- a/packages/node-sdk/src/flusher.ts
+++ b/packages/node-sdk/src/flusher.ts
@@ -46,7 +46,7 @@ export function subscribe(
     } else {
       process.on(signal, async () => {
         await wrappedCallback();
-        process.exit(0x100 + constants.signals[signal]);
+        process.exit(0x80 + constants.signals[signal]);
       });
     }
   });

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -288,13 +288,24 @@ export type BatchBufferOptions<T> = {
 
   /**
    * The maximum size of the buffer before it is flushed.
+   *
+   * @defaultValue `100`
    **/
   maxSize?: number;
 
   /**
    * The interval in milliseconds at which the buffer is flushed.
+   *
+   * @defaultValue `1000`
    **/
   intervalMs?: number;
+
+  /**
+   * Whether to flush the buffer on exit.
+   *
+   * @defaultValue `true`
+   */
+  flushOnExit?: boolean;
 };
 
 /**

--- a/packages/node-sdk/src/utils.ts
+++ b/packages/node-sdk/src/utils.ts
@@ -175,3 +175,44 @@ export function once<T extends () => ReturnType<T>>(
     return returned;
   };
 }
+
+export class TimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Operation timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * Wraps a promise with a timeout. If the promise doesn't resolve within the specified
+ * timeout, it will reject with a timeout error. The original promise will still
+ * continue to execute but its result will be ignored.
+ *
+ * @param promise - The promise to wrap with a timeout
+ * @param timeoutMs - The timeout in milliseconds
+ * @returns A promise that resolves with the original promise result or rejects with a timeout error
+ * @throws {Error} If the timeout is reached before the promise resolves
+ **/
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  ok(timeoutMs > 0, "timeout must be a positive number");
+
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      reject(new TimeoutError(timeoutMs));
+    }, timeoutMs);
+
+    promise
+      .then((result) => {
+        resolve(result);
+      })
+      .catch((error) => {
+        reject(error);
+      })
+      .finally(() => {
+        clearTimeout(timeoutId);
+      });
+  });
+}

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -315,6 +315,15 @@ describe("BucketClient", () => {
       expect(triggerOnExit).not.toHaveBeenCalled();
     });
 
+    it("should not register an exit flush handler if `offline` is true", () => {
+      new BucketClient({
+        ...validOptions,
+        offline: true,
+      });
+
+      expect(triggerOnExit).not.toHaveBeenCalled();
+    });
+
     it.each([undefined, true])(
       "should register an exit flush handler if `batchOptions.flushOnExit` is `%s`",
       (flushOnExit) => {
@@ -927,6 +936,18 @@ describe("BucketClient", () => {
           },
         ],
       );
+    });
+
+    it("should not flush all bulk data if `offline` is true", async () => {
+      const client = new BucketClient({
+        ...validOptions,
+        offline: true,
+      });
+
+      await client.updateUser(user.id, { attributes: { age: 2 } });
+      await client.flush();
+
+      expect(httpClient.post).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -23,6 +23,7 @@ import {
   SDK_VERSION_HEADER_NAME,
 } from "../src/config";
 import fetchClient from "../src/fetch-http-client";
+import { subscribe as triggerOnExit } from "../src/flusher";
 import { newRateLimiter } from "../src/rate-limiter";
 import { ClientOptions, Context, FeaturesAPIResponse } from "../src/types";
 
@@ -44,6 +45,10 @@ vi.mock("../src/rate-limiter", async (importOriginal) => {
     newRateLimiter: vi.fn(original.newRateLimiter),
   };
 });
+
+vi.mock("../src/flusher", () => ({
+  subscribe: vi.fn(),
+}));
 
 const user = {
   id: "user123",
@@ -82,6 +87,7 @@ const validOptions: ClientOptions = {
   batchOptions: {
     maxSize: 99,
     intervalMs: 100,
+    flushOnExit: false,
   },
   offline: false,
 };
@@ -299,6 +305,27 @@ describe("BucketClient", () => {
         FEATURE_EVENT_RATE_LIMITER_WINDOW_SIZE_MS,
       );
     });
+
+    it("should not register an exit flush handler if `batchOptions.flushOnExit` is false", () => {
+      new BucketClient({
+        ...validOptions,
+        batchOptions: { ...validOptions.batchOptions, flushOnExit: false },
+      });
+
+      expect(triggerOnExit).not.toHaveBeenCalled();
+    });
+
+    it.each([undefined, true])(
+      "should register an exit flush handler if `batchOptions.flushOnExit` is `%s`",
+      (flushOnExit) => {
+        new BucketClient({
+          ...validOptions,
+          batchOptions: { ...validOptions.batchOptions, flushOnExit },
+        });
+
+        expect(triggerOnExit).toHaveBeenCalledWith(expect.any(Function));
+      },
+    );
 
     it.each([
       ["https://api.example.com", "https://api.example.com/bulk"],

--- a/packages/node-sdk/test/flusher.test.ts
+++ b/packages/node-sdk/test/flusher.test.ts
@@ -79,9 +79,7 @@ describe("flusher", () => {
         await vi.runAllTimersAsync();
 
         expect(callback).toHaveBeenCalledTimes(1);
-        expect(mockExit).toHaveBeenCalledWith(
-          0x100 + constants.signals[signal],
-        );
+        expect(mockExit).toHaveBeenCalledWith(0x80 + constants.signals[signal]);
       });
 
       it("should prepend handler when listeners exist", async () => {

--- a/packages/node-sdk/test/flusher.test.ts
+++ b/packages/node-sdk/test/flusher.test.ts
@@ -1,0 +1,212 @@
+import { constants } from "os";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  MockInstance,
+  vi,
+} from "vitest";
+
+import { subscribe } from "../src/flusher";
+
+describe("flusher", () => {
+  const mockExit = vi
+    .spyOn(process, "exit")
+    .mockImplementation((() => undefined) as any);
+
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => undefined);
+
+  const mockProcessOn = vi
+    .spyOn(process, "on")
+    .mockImplementation((_, __) => process);
+
+  const mockProcessPrependListener = (
+    vi.spyOn(process, "prependListener") as unknown as MockInstance<
+      [event: NodeJS.Signals, listener: NodeJS.SignalsListener],
+      NodeJS.Process
+    >
+  ).mockImplementation((_, __) => process);
+
+  const mockListenerCount = vi
+    .spyOn(process, "listenerCount")
+    .mockReturnValue(0);
+
+  function timedCallback(ms: number) {
+    return vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(resolve, ms);
+        }),
+    );
+  }
+
+  function getHandler(eventName: string, prepended = false) {
+    return prepended
+      ? mockProcessPrependListener.mock.calls.filter(
+          ([evt]) => evt === eventName,
+        )[0][1]
+      : mockProcessOn.mock.calls.filter(([evt]) => evt === eventName)[0][1];
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetAllMocks();
+  });
+
+  describe("signal handling", () => {
+    const signals = ["SIGINT", "SIGTERM", "SIGHUP", "SIGBREAK"] as const;
+
+    describe.each(signals)("signal %s", (signal) => {
+      it("should handle signal with no existing listeners", async () => {
+        mockListenerCount.mockReturnValue(0);
+        const callback = vi.fn().mockResolvedValue(undefined);
+
+        subscribe(callback);
+        expect(mockProcessOn).toHaveBeenCalledWith(
+          signal,
+          expect.any(Function),
+        );
+
+        getHandler(signal)(signal);
+        await vi.runAllTimersAsync();
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(mockExit).toHaveBeenCalledWith(
+          0x100 + constants.signals[signal],
+        );
+      });
+
+      it("should prepend handler when listeners exist", async () => {
+        mockListenerCount.mockReturnValue(1);
+        const callback = vi.fn().mockResolvedValue(undefined);
+
+        subscribe(callback);
+
+        expect(mockProcessPrependListener).toHaveBeenCalledWith(
+          signal,
+          expect.any(Function),
+        );
+
+        getHandler(signal, true)(signal);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(mockExit).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("beforeExit handling", () => {
+    it("should call callback on beforeExit", async () => {
+      const callback = vi.fn().mockResolvedValue(undefined);
+
+      subscribe(callback);
+
+      getHandler("beforeExit")();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not call callback multiple times", async () => {
+      const callback = vi.fn().mockResolvedValue(undefined);
+
+      subscribe(callback);
+
+      getHandler("beforeExit")();
+      getHandler("beforeExit")();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("timeout handling", () => {
+    it("should handle timeout when callback takes too long", async () => {
+      subscribe(timedCallback(2000), 1000);
+
+      getHandler("beforeExit")();
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        "[Bucket SDK] Timeout while flushing events on process exit.",
+      );
+    });
+
+    it("should not timeout when callback completes in time", async () => {
+      subscribe(timedCallback(500), 1000);
+
+      getHandler("beforeExit")();
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(mockConsoleError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("exit state handling", () => {
+    it("should log error if exit occurs before flushing starts", () => {
+      subscribe(timedCallback(0));
+
+      getHandler("exit")();
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        "[Bucket SDK] Failed to finalize the flushing of events on process exit.",
+      );
+    });
+
+    it("should log error if exit occurs before flushing completes", async () => {
+      subscribe(timedCallback(2000));
+      getHandler("beforeExit")();
+
+      await vi.advanceTimersByTimeAsync(1000);
+
+      getHandler("exit")();
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        "[Bucket SDK] Failed to finalize the flushing of events on process exit.",
+      );
+    });
+
+    it("should not log error if flushing completes before exit", async () => {
+      subscribe(timedCallback(500));
+
+      getHandler("beforeExit")();
+      await vi.advanceTimersByTimeAsync(500);
+
+      getHandler("exit")();
+
+      expect(mockConsoleError).not.toHaveBeenCalled();
+    });
+
+    it("should handle callback errors gracefully", async () => {
+      subscribe(vi.fn().mockRejectedValue(new Error("Test error")));
+
+      getHandler("beforeExit")();
+      await vi.runAllTimersAsync();
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        "[Bucket SDK] An error occurred while flushing events on process exit.",
+        expect.any(Error),
+      );
+    });
+  });
+
+  it("should run the callback only once", async () => {
+    const callback = vi.fn().mockResolvedValue(undefined);
+
+    subscribe(callback);
+
+    getHandler("SIGINT")("SIGINT");
+    getHandler("beforeExit")();
+
+    await vi.runAllTimersAsync();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node-sdk/test/utils.test.ts
+++ b/packages/node-sdk/test/utils.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   decorateLogger,
@@ -8,8 +8,8 @@ import {
   mergeSkipUndefined,
   ok,
   once,
-  withTimeout,
   TimeoutError,
+  withTimeout,
 } from "../src/utils";
 
 describe("isObject", () => {


### PR DESCRIPTION
This PR Introduces `flushOnExit` option in batch buffer configuration. When on (default), the client will flush all events on it's exit.
