### PR TITLE
feat: use remote feature list instead of locally defined list

### DIFF
--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -404,7 +404,6 @@ export class BucketClient {
         company: this.context.company,
         other: this.context.otherContext,
       },
-      opts?.features || [],
       this.logger,
       {
         expireTimeMs: opts.expireTimeMs,

--- a/packages/browser-sdk/src/feature/features.ts
+++ b/packages/browser-sdk/src/feature/features.ts
@@ -187,7 +187,6 @@ export class FeaturesClient {
   constructor(
     private httpClient: HttpClient,
     private context: context,
-    private featureDefinitions: Readonly<string[]>,
     logger: Logger,
     options?: {
       fallbackFeatures?: Record<string, FallbackFeatureOverride> | string[];
@@ -235,9 +234,7 @@ export class FeaturesClient {
     try {
       const storedFeatureOverrides = getOverridesCache();
       for (const key in storedFeatureOverrides) {
-        if (this.featureDefinitions.includes(key)) {
-          this.featureOverrides[key] = storedFeatureOverrides[key];
-        }
+        this.featureOverrides[key] = storedFeatureOverrides[key];
       }
     } catch (e) {
       this.logger.warn("error getting feature overrides from cache", e);
@@ -295,7 +292,7 @@ export class FeaturesClient {
     const params = this.fetchParams();
     try {
       const res = await this.httpClient.get({
-        path: "/features/enabled",
+        path: "/features/evaluated",
         timeoutMs: this.config.timeoutMs,
         params,
       });
@@ -373,17 +370,6 @@ export class FeaturesClient {
         ...fetchedFeature,
         isEnabledOverride,
       };
-    }
-
-    // add any features that aren't in the fetched features
-    for (const key of this.featureDefinitions) {
-      if (!mergedFeatures[key]) {
-        mergedFeatures[key] = {
-          key,
-          isEnabled: false,
-          isEnabledOverride: this.featureOverrides[key] ?? null,
-        };
-      }
     }
 
     this.features = mergedFeatures;

--- a/packages/browser-sdk/test/e2e/acceptance.browser.spec.ts
+++ b/packages/browser-sdk/test/e2e/acceptance.browser.spec.ts
@@ -11,7 +11,7 @@ test("Acceptance", async ({ page }) => {
   const successfulRequests: string[] = [];
 
   // Mock API calls with assertions
-  await page.route(`${API_BASE_URL}/features/enabled*`, async (route) => {
+  await page.route(`${API_BASE_URL}/features/evaluated*`, async (route) => {
     successfulRequests.push("FEATURES");
     await route.fulfill({
       status: 200,

--- a/packages/browser-sdk/test/e2e/feedback-widget.browser.spec.ts
+++ b/packages/browser-sdk/test/e2e/feedback-widget.browser.spec.ts
@@ -33,7 +33,7 @@ async function getOpenedWidgetContainer(
     await route.fulfill({ status: 200 });
   });
 
-  await page.route(`${API_HOST}/features/enabled*`, async (route) => {
+  await page.route(`${API_HOST}/features/evaluated*`, async (route) => {
     await route.fulfill({
       status: 200,
       body: JSON.stringify({
@@ -70,7 +70,7 @@ async function getGiveFeedbackPageContainer(
     await route.fulfill({ status: 200 });
   });
 
-  await page.route(`${API_HOST}/features/enabled*`, async (route) => {
+  await page.route(`${API_HOST}/features/evaluated*`, async (route) => {
     await route.fulfill({
       status: 200,
       body: JSON.stringify({

--- a/packages/browser-sdk/test/features.test.ts
+++ b/packages/browser-sdk/test/features.test.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { version } from "../package.json";
-import { FeatureDefinitions } from "../src/client";
 import {
   FEATURES_EXPIRE_MS,
   FeaturesClient,
@@ -37,7 +36,6 @@ function featuresClientFactory() {
     httpClient,
     newFeaturesClient: function newFeaturesClient(
       context?: Record<string, any>,
-      features?: FeatureDefinitions,
       options?: { staleWhileRevalidate?: boolean; fallbackFeatures?: any },
     ) {
       return new FeaturesClient(
@@ -48,7 +46,6 @@ function featuresClientFactory() {
           other: { eventId: "big-conference1" },
           ...context,
         },
-        features || [],
         testLogger,
         {
           cache,
@@ -87,7 +84,7 @@ describe("FeaturesClient", () => {
       publishableKey: "pk",
     });
 
-    expect(path).toEqual("/features/enabled");
+    expect(path).toEqual("/features/evaluated");
     expect(timeoutMs).toEqual(5000);
   });
 
@@ -111,7 +108,7 @@ describe("FeaturesClient", () => {
       publishableKey: "pk",
     });
 
-    expect(path).toEqual("/features/enabled");
+    expect(path).toEqual("/features/evaluated");
     expect(timeoutMs).toEqual(5000);
   });
 
@@ -122,7 +119,7 @@ describe("FeaturesClient", () => {
       new Error("Failed to fetch features"),
     );
 
-    const featuresClient = newFeaturesClient(undefined, undefined, {
+    const featuresClient = newFeaturesClient(undefined, {
       fallbackFeatures: ["huddle"],
     });
 
@@ -143,7 +140,7 @@ describe("FeaturesClient", () => {
     vi.mocked(httpClient.get).mockRejectedValue(
       new Error("Failed to fetch features"),
     );
-    const featuresClient = newFeaturesClient(undefined, undefined, {
+    const featuresClient = newFeaturesClient(undefined, {
       fallbackFeatures: {
         huddle: {
           key: "john",
@@ -342,7 +339,7 @@ describe("FeaturesClient", () => {
     const { newFeaturesClient } = featuresClientFactory();
 
     // localStorage.clear();
-    const client = newFeaturesClient(undefined, ["featureB"]);
+    const client = newFeaturesClient(undefined);
     await client.initialize();
 
     let updated = false;

--- a/packages/browser-sdk/test/init.test.ts
+++ b/packages/browser-sdk/test/init.test.ts
@@ -40,7 +40,7 @@ describe("init", () => {
 
     server.use(
       http.get(
-        "https://example.com/features/enabled",
+        "https://example.com/features/evaluated",
         ({ request }: { request: StrictRequest<DefaultBodyType> }) => {
           usedSpecialHost = true;
           return getFeatures({ request });

--- a/packages/browser-sdk/test/mocks/handlers.ts
+++ b/packages/browser-sdk/test/mocks/handlers.ts
@@ -151,6 +151,7 @@ export const handlers = [
     });
   }),
   http.get("https://front.bucket.co/features/enabled", getFeatures),
+  http.get("https://front.bucket.co/features/evaluated", getFeatures),
   http.post(
     "https://front.bucket.co/feedback/prompting-init",
     ({ request }) => {

--- a/packages/node-sdk/example/serve.ts
+++ b/packages/node-sdk/example/serve.ts
@@ -4,8 +4,6 @@ import app from "./app";
 // Initialize Bucket SDK before starting the server,
 // so that features are available when the server starts.
 bucket.initialize().then(() => {
-  console.log("Bucket initialized");
-
   // Start listening for requests only after Bucket is initialized,
   // which guarantees that features are available.
   app.listen(process.env.PORT ?? 3000, () => {

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -72,7 +72,7 @@ const server = setupServer(
       { status: 200 },
     );
   }),
-  http.get(/\/features\/enabled$/, () => {
+  http.get(/\/features\/evaluated$/, () => {
     return new HttpResponse(
       JSON.stringify({
         success: true,


### PR DESCRIPTION
This removes the need to pass in a feature list to the SDK in order for features to show up in the toolbar. Instead, we'll use the `/features/evaluated` endpoint which returns all features. 