### PR TITLE
chore: upgrade typedoc-plugin-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier": "^3.3.3",
     "typedoc": "0.27.6",
     "typedoc-plugin-frontmatter": "^1.1.2",
-    "typedoc-plugin-markdown": "^4.4.1",
+    "typedoc-plugin-markdown": "^4.4.2",
     "typedoc-plugin-mdn-links": "^4.0.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15091,12 +15091,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "typedoc-plugin-markdown@npm:4.4.1"
+"typedoc-plugin-markdown@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "typedoc-plugin-markdown@npm:4.4.2"
   peerDependencies:
     typedoc: 0.27.x
-  checksum: 10c0/54c9a25aed64d07258033c4d060acac15a618ee0494cbb2bc70fd10d03c82b3434715b6db01fbeb09d672cff736340666d70da1be83188e3a994048a0a0c6b65
+  checksum: 10c0/93112f0f06f1c0bc7eec1ba7f9034b88a6817a92ec41e491e8ac73c23a5fbda84df537d136395295737499fc1d5afa94d1500a1921b1a967248dc5d3054fc9d6
   languageName: node
   linkType: hard
 
@@ -16111,7 +16111,7 @@ __metadata:
     prettier: "npm:^3.3.3"
     typedoc: "npm:0.27.6"
     typedoc-plugin-frontmatter: "npm:^1.1.2"
-    typedoc-plugin-markdown: "npm:^4.4.1"
+    typedoc-plugin-markdown: "npm:^4.4.2"
     typedoc-plugin-mdn-links: "npm:^4.0.7"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
New version has a fix I made for links to project documents.
https://github.com/typedoc2md/typedoc-plugin-markdown/blob/main/packages/typedoc-plugin-markdown/CHANGELOG.md#442