### PR TITLE
docs(browser-sdk): make feature overrides internal for now

### DIFF
--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -172,26 +172,6 @@ by down-stream clients, like the React SDK.
 Note that accessing `isEnabled` on the object returned by `getFeatures` does not automatically
 generate a `check` event, contrary to the `isEnabled` property on the object returned by `getFeature`.
 
-### Feature Overrides
-
-You can override feature flags locally for testing purposes using `setFeatureOverride`:
-
-```ts
-// Override a feature to be enabled
-bucketClient.setFeatureOverride("huddle", true);
-
-// Override a feature to be disabled
-bucketClient.setFeatureOverride("huddle", false);
-
-// Remove the override
-bucketClient.setFeatureOverride("huddle", null);
-
-// Get current override value
-const override = bucketClient.getFeatureOverride("huddle"); // returns boolean | null
-```
-
-Feature overrides are persisted in `localStorage` and will be restored when the page is reloaded.
-
 ### Remote config
 
 Similar to `isEnabled`, each feature has a `config` property. This configuration is managed from within Bucket.

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -770,15 +770,21 @@ export class BucketClient {
     };
   }
 
+  /**
+   * @internal
+   */
   setFeatureOverride(key: string, isEnabled: boolean | null) {
     this.featuresClient.setFeatureOverride(key, isEnabled);
   }
 
+  /**
+   * @internal
+   */
   getFeatureOverride(key: string): boolean | null {
     return this.featuresClient.getFeatureOverride(key);
   }
 
-  sendCheckEvent(checkEvent: CheckEvent) {
+  private sendCheckEvent(checkEvent: CheckEvent) {
     return this.featuresClient.sendCheckEvent(checkEvent, () => {
       this.hooks.trigger(
         checkEvent.action == "check-config" ? "configCheck" : "enabledCheck",

--- a/packages/browser-sdk/src/feature/features.ts
+++ b/packages/browser-sdk/src/feature/features.ts
@@ -20,6 +20,7 @@ export type FetchedFeature = {
 
   /**
    * Result of feature flag evaluation.
+   * Note: does not take local overrides into account.
    */
   isEnabled: boolean;
 
@@ -71,9 +72,11 @@ export type FetchedFeature = {
 
 const FEATURES_UPDATED_EVENT = "featuresUpdated";
 
+/**
+ * @internal
+ */
 export type FetchedFeatures = Record<string, FetchedFeature | undefined>;
 
-// todo: on next major, come up with a better name for this type. Maybe `LocalFeature`.
 export type RawFeature = FetchedFeature & {
   /**
    * If not null, the result is being overridden locally


### PR DESCRIPTION
We'll be moving exposing feature overrides through what is returned from the `getFeature()` call rather than exposing it directly on the client.