### PR TITLE
fix(browser-sdk): fix e2e test stability

### DIFF
--- a/packages/browser-sdk/playwright.config.ts
+++ b/packages/browser-sdk/playwright.config.ts
@@ -34,5 +34,6 @@ export default defineConfig({
     // separate port to let the app run alongside the tracking sdk tests
     command: "npx http-server . -p 8001",
     timeout: 120 * 1000,
+    port: 8001,
   },
 });


### PR DESCRIPTION
Setting a port will make playwright wait until the server is listening