### PR TITLE
feat(browser-sdk): introduce `credential` config option

### DIFF
--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -257,6 +257,13 @@ export type InitOptions = {
   staleTimeMs?: number;
 
   /**
+   * When proxying requests, you may want to include credentials like cookies
+   * so you can authorize the request in the proxy.
+   * This option controls the `credentials` option of the fetch API.
+   */
+  credentials?: "include" | "same-origin" | "omit";
+
+  /**
    * Base URL of Bucket servers for SSE connections used by AutoFeedback.
    */
   sseBaseUrl?: string;

--- a/packages/browser-sdk/test/httpClient.test.ts
+++ b/packages/browser-sdk/test/httpClient.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, describe, vi, beforeEach, afterEach } from "vitest";
 
 import { HttpClient } from "../src/httpClient";
 
@@ -19,4 +19,45 @@ test.each(cases)(
 test.each(cases)("url construction with `path`: %s -> %s", (base, expected) => {
   const client = new HttpClient("publishableKey", { baseUrl: base });
   expect(client.getUrl("path").toString()).toBe(expected);
+});
+
+describe("sets `credentials`", () => {
+  beforeEach(() => {
+    vi.spyOn(global, "fetch").mockResolvedValue(new Response());
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+  test("default credentials", async () => {
+    const client = new HttpClient("publishableKey");
+
+    await client.get({ path: "/test" });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({ credentials: undefined }),
+    );
+
+    await client.post({ path: "/test", body: {} });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({ credentials: undefined }),
+    );
+  });
+
+  test("custom credentials", async () => {
+    const client = new HttpClient("publishableKey", { credentials: "include" });
+
+    await client.get({ path: "/test" });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({ credentials: "include" }),
+    );
+
+    await client.post({ path: "/test", body: {} });
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
 });

--- a/packages/browser-sdk/test/init.test.ts
+++ b/packages/browser-sdk/test/init.test.ts
@@ -89,4 +89,19 @@ describe("init", () => {
 
     expect(post).not.toHaveBeenCalled();
   });
+
+  test("passes credentials correctly to httpClient", async () => {
+    const credentials = "include";
+    const bucketInstance = new BucketClient({
+      publishableKey: KEY,
+      user: { id: "foo" },
+      credentials,
+    });
+
+    await bucketInstance.initialize();
+
+    expect(bucketInstance["httpClient"]["fetchOptions"].credentials).toBe(
+      credentials,
+    );
+  });
 });


### PR DESCRIPTION
When proxying requests, you may want to include credentials like cookies so you can authorize the request in the proxy.
This option controls the `credentials` option of the fetch API.