### PR TITLE
fix:(browser-sdk,react-sdk): consolidated specific enabled/config check listeners

### DIFF
--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -274,8 +274,7 @@ See details in [Feedback HTTP API](https://docs.bucket.co/reference/http-trackin
 
 Event listeners allow for capturing various events occurring in the `BucketClient`. This is useful to build integrations with other system or for various debugging purposes. There are 5 kinds of events:
 
-- `configCheck`: Your code used a feature config
-- `enabledCheck`: Your code checked whether a specific feature should be enabled
+- `check`: Your code used `isEnabled` or `config` for a feature
 - `featuresUpdated`: Features were updated. Either because they were loaded as part of initialization or because the user/company updated
 - `user`: User information updated (similar to the `identify` call used in tracking terminology)
 - `company`: Company information updated (sometimes to the `group` call used in tracking terminology)

--- a/packages/browser-sdk/index.html
+++ b/packages/browser-sdk/index.html
@@ -54,7 +54,7 @@
         document.getElementById("loading").style.display = "none";
       });
 
-      bucket.on("enabledCheck", (check) =>
+      bucket.on("check", (check) =>
         console.log(`Check event for ${check.key}`),
       );
 

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/browser-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "packageManager": "yarn@4.1.1",
   "license": "MIT",
   "repository": {

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -799,6 +799,7 @@ export class BucketClient {
         checkEvent.action == "check-config" ? "configCheck" : "enabledCheck",
         checkEvent,
       );
+      this.hooks.trigger("check", checkEvent);
     });
   }
 

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -480,30 +480,31 @@ export class BucketClient {
   }
 
   /**
-   * Add a hook to the client.
+   * Add an event listener
    *
-   * @param hook Hook to add.
+   * @param type Type of events to listen for
+   * @param handler The function to call when the event is triggered.
    * @returns A function to remove the hook.
    */
   on<THookType extends keyof HookArgs>(
     type: THookType,
     handler: (args0: HookArgs[THookType]) => void,
   ) {
-    this.hooks.addHook(type, handler);
-    return () => this.hooks.removeHook(type, handler);
+    return this.hooks.addHook(type, handler);
   }
 
   /**
-   * Remove a hook from the client.
+   * Remove an event listener
    *
-   * @param hook Hook to add.
-   * @returns A function to remove the hook.
+   * @param type Type of event to remove.
+   * @param handler The same function that was passed to `on`.
+   *
    */
   off<THookType extends keyof HookArgs>(
     type: THookType,
     handler: (args0: HookArgs[THookType]) => void,
   ) {
-    return this.hooks.removeHook(type, handler);
+    this.hooks.removeHook(type, handler);
   }
 
   /**

--- a/packages/browser-sdk/src/hooksManager.ts
+++ b/packages/browser-sdk/src/hooksManager.ts
@@ -5,8 +5,17 @@ import { CompanyContext, UserContext } from "./context";
  * @internal
  */
 export interface HookArgs {
+  /**
+   * Deprecated: Use `check` instead.
+   * @deprecated
+   */
   configCheck: CheckEvent;
+  /**
+   * Deprecated: Use `check` instead.
+   * @deprecated
+   */
   enabledCheck: CheckEvent;
+  check: CheckEvent;
   featuresUpdated: RawFeatures;
   user: UserContext;
   company: CompanyContext;
@@ -28,6 +37,7 @@ export class HooksManager {
   private hooks: {
     enabledCheck: ((arg0: CheckEvent) => void)[];
     configCheck: ((arg0: CheckEvent) => void)[];
+    check: ((arg0: CheckEvent) => void)[];
     featuresUpdated: ((arg0: RawFeatures) => void)[];
     user: ((arg0: UserContext) => void)[];
     company: ((arg0: CompanyContext) => void)[];
@@ -35,6 +45,7 @@ export class HooksManager {
   } = {
     enabledCheck: [],
     configCheck: [],
+    check: [],
     featuresUpdated: [],
     user: [],
     company: [],

--- a/packages/browser-sdk/test/client.test.ts
+++ b/packages/browser-sdk/test/client.test.ts
@@ -136,6 +136,7 @@ describe("BucketClient", () => {
       trackHook.mockReset();
       userHook.mockReset();
       companyHook.mockReset();
+      checkHook.mockReset();
       checkHookIsEnabled.mockReset();
       checkHookConfig.mockReset();
       featuresUpdated.mockReset();

--- a/packages/browser-sdk/test/client.test.ts
+++ b/packages/browser-sdk/test/client.test.ts
@@ -80,6 +80,7 @@ describe("BucketClient", () => {
       const trackHook = vi.fn();
       const userHook = vi.fn();
       const companyHook = vi.fn();
+      const checkHook = vi.fn();
       const checkHookIsEnabled = vi.fn();
       const checkHookConfig = vi.fn();
       const featuresUpdated = vi.fn();
@@ -87,6 +88,7 @@ describe("BucketClient", () => {
       client.on("track", trackHook);
       client.on("user", userHook);
       client.on("company", companyHook);
+      client.on("check", checkHook);
       client.on("configCheck", checkHookConfig);
       client.on("enabledCheck", checkHookIsEnabled);
       client.on("featuresUpdated", featuresUpdated);
@@ -108,10 +110,14 @@ describe("BucketClient", () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- special getter triggering event
       client.getFeature("featureA").isEnabled;
       expect(checkHookIsEnabled).toHaveBeenCalled();
+      expect(checkHook).toHaveBeenCalled();
+
+      checkHook.mockReset();
 
       // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- special getter triggering event
       client.getFeature("featureA").config;
       expect(checkHookConfig).toHaveBeenCalled();
+      expect(checkHook).toHaveBeenCalled();
 
       expect(featuresUpdated).not.toHaveBeenCalled();
       await client.updateOtherContext({ key: "value" });
@@ -121,6 +127,7 @@ describe("BucketClient", () => {
       client.off("track", trackHook);
       client.off("user", userHook);
       client.off("company", companyHook);
+      client.off("check", checkHook);
       client.off("configCheck", checkHookConfig);
       client.off("enabledCheck", checkHookIsEnabled);
       client.off("featuresUpdated", featuresUpdated);
@@ -147,6 +154,7 @@ describe("BucketClient", () => {
       expect(trackHook).not.toHaveBeenCalled();
       expect(userHook).not.toHaveBeenCalled();
       expect(companyHook).not.toHaveBeenCalled();
+      expect(checkHook).not.toHaveBeenCalled();
       expect(checkHookIsEnabled).not.toHaveBeenCalled();
       expect(checkHookConfig).not.toHaveBeenCalled();
       expect(featuresUpdated).not.toHaveBeenCalled();

--- a/packages/browser-sdk/test/hooksManager.test.ts
+++ b/packages/browser-sdk/test/hooksManager.test.ts
@@ -11,7 +11,7 @@ describe("HookManager", () => {
     hookManager = new HooksManager();
   });
 
-  it("should add and trigger check-is-enabled hooks", () => {
+  it("should add and trigger `check` hooks", () => {
     const callback = vi.fn();
     hookManager.addHook("check", callback);
 
@@ -25,7 +25,7 @@ describe("HookManager", () => {
     expect(callback).toHaveBeenCalledWith(checkEvent);
   });
 
-  it("should add and trigger enabledCheck hooks", () => {
+  it("should add and trigger `enabledCheck` hooks", () => {
     const callback = vi.fn();
     hookManager.addHook("enabledCheck", callback);
 
@@ -39,7 +39,7 @@ describe("HookManager", () => {
     expect(callback).toHaveBeenCalledWith(checkEvent);
   });
 
-  it("should add and trigger configCheck hooks", () => {
+  it("should add and trigger `configCheck` hooks", () => {
     const callback = vi.fn();
     hookManager.addHook("configCheck", callback);
 
@@ -53,7 +53,7 @@ describe("HookManager", () => {
     expect(callback).toHaveBeenCalledWith(checkEvent);
   });
 
-  it("should add and trigger features-updated hooks", () => {
+  it("should add and trigger `featuresUpdated` hooks", () => {
     const callback = vi.fn();
     hookManager.addHook("featuresUpdated", callback);
 
@@ -65,7 +65,7 @@ describe("HookManager", () => {
     expect(callback).toHaveBeenCalledWith(features);
   });
 
-  it("should add and trigger track hooks", () => {
+  it("should add and trigger `track` hooks", () => {
     const callback = vi.fn();
     const user: UserContext = { id: "user-id", name: "user-name" };
     const company: CompanyContext = { id: "company-id", name: "company-name" };
@@ -83,7 +83,7 @@ describe("HookManager", () => {
     });
   });
 
-  it("should add and trigger user hooks", () => {
+  it("should add and trigger `user` hooks", () => {
     const callback = vi.fn();
 
     hookManager.addHook("user", callback);
@@ -94,7 +94,7 @@ describe("HookManager", () => {
     expect(callback).toHaveBeenCalledWith(user);
   });
 
-  it("should add and trigger company hooks", () => {
+  it("should add and trigger `company` hooks", () => {
     const callback = vi.fn();
     hookManager.addHook("company", callback);
 

--- a/packages/browser-sdk/test/hooksManager.test.ts
+++ b/packages/browser-sdk/test/hooksManager.test.ts
@@ -13,6 +13,20 @@ describe("HookManager", () => {
 
   it("should add and trigger check-is-enabled hooks", () => {
     const callback = vi.fn();
+    hookManager.addHook("check", callback);
+
+    const checkEvent: CheckEvent = {
+      action: "check-is-enabled",
+      key: "test-key",
+      value: true,
+    };
+    hookManager.trigger("check", checkEvent);
+
+    expect(callback).toHaveBeenCalledWith(checkEvent);
+  });
+
+  it("should add and trigger enabledCheck hooks", () => {
+    const callback = vi.fn();
     hookManager.addHook("enabledCheck", callback);
 
     const checkEvent: CheckEvent = {
@@ -94,15 +108,15 @@ describe("HookManager", () => {
     const callback1 = vi.fn();
     const callback2 = vi.fn();
 
-    hookManager.addHook("enabledCheck", callback1);
-    hookManager.addHook("enabledCheck", callback2);
+    hookManager.addHook("check", callback1);
+    hookManager.addHook("check", callback2);
 
     const checkEvent: CheckEvent = {
       action: "check-is-enabled",
       key: "test-key",
       value: true,
     };
-    hookManager.trigger("enabledCheck", checkEvent);
+    hookManager.trigger("check", checkEvent);
 
     expect(callback1).toHaveBeenCalledWith(checkEvent);
     expect(callback2).toHaveBeenCalledWith(checkEvent);
@@ -112,16 +126,16 @@ describe("HookManager", () => {
     const callback1 = vi.fn();
     const callback2 = vi.fn();
 
-    hookManager.addHook("enabledCheck", callback1);
-    hookManager.addHook("enabledCheck", callback2);
-    hookManager.removeHook("enabledCheck", callback1);
+    hookManager.addHook("check", callback1);
+    hookManager.addHook("check", callback2);
+    hookManager.removeHook("check", callback1);
 
     const checkEvent: CheckEvent = {
       action: "check-is-enabled",
       key: "test-key",
       value: true,
     };
-    hookManager.trigger("enabledCheck", checkEvent);
+    hookManager.trigger("check", checkEvent);
 
     expect(callback1).not.toHaveBeenCalled();
     expect(callback2).toHaveBeenCalledWith(checkEvent);
@@ -131,8 +145,8 @@ describe("HookManager", () => {
     const callback1 = vi.fn();
     const callback2 = vi.fn();
 
-    const removeHook1 = hookManager.addHook("enabledCheck", callback1);
-    hookManager.addHook("enabledCheck", callback2);
+    const removeHook1 = hookManager.addHook("check", callback1);
+    hookManager.addHook("check", callback2);
     removeHook1();
 
     const checkEvent: CheckEvent = {
@@ -140,7 +154,7 @@ describe("HookManager", () => {
       key: "test-key",
       value: true,
     };
-    hookManager.trigger("enabledCheck", checkEvent);
+    hookManager.trigger("check", checkEvent);
 
     expect(callback1).not.toHaveBeenCalled();
     expect(callback2).toHaveBeenCalledWith(checkEvent);

--- a/packages/openfeature-browser-provider/package.json
+++ b/packages/openfeature-browser-provider/package.json
@@ -29,9 +29,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/bucket-openfeature-browser-provider.mjs",
-      "require": "./dist/bucket-openfeature-browser-provider.umd.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/bucket-openfeature-browser-provider.umd.js"
     }
   },
   "dependencies": {

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -409,7 +409,7 @@ function LoggingWrapper({ children }: { children: ReactNode }) {
   const client = useClient();
 
   useEffect(() => {
-    client.on("enabledCheck", (evt) => {
+    client.on("check", (evt) => {
       console.log(`The feature ${evt.key} is ${evt.value} for user.`);
     });
   }, [client]);

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/react-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     }
   },
   "dependencies": {
-    "@bucketco/browser-sdk": "3.1.0",
+    "@bucketco/browser-sdk": "3.1.1",
     "canonical-json": "^0.0.4",
     "rollup": "^4.2.0"
   },

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -362,8 +362,8 @@ export function useUpdateOtherContext() {
  * ```ts
  * const client = useClient();
  * useEffect(() => {
- *   return client?.on("enabledCheck", () => {
- *     console.log("enabledCheck hook called");
+ *   return client?.on("check", () => {
+ *     console.log("check hook called");
  *   });
  * }, [client]);
  * ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,7 +417,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bucketco/browser-sdk@npm:3.1.0, @bucketco/browser-sdk@workspace:packages/browser-sdk":
+"@bucketco/browser-sdk@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@bucketco/browser-sdk@npm:3.1.0"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.6.8"
+    canonical-json: "npm:^0.0.4"
+    js-cookie: "npm:^3.0.5"
+    preact: "npm:^10.22.1"
+  checksum: 10c0/a53174fa826b990087ef434f3d9cb09dbd80b707783fa208d872f499b42e7dcebe326ff78225aa621670138c0059d60361e68903fd129dd25af1ed0d85a1428d
+  languageName: node
+  linkType: hard
+
+"@bucketco/browser-sdk@npm:3.1.1, @bucketco/browser-sdk@workspace:packages/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/browser-sdk@workspace:packages/browser-sdk"
   dependencies:
@@ -580,7 +592,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bucketco/react-sdk@workspace:packages/react-sdk"
   dependencies:
-    "@bucketco/browser-sdk": "npm:3.1.0"
+    "@bucketco/browser-sdk": "npm:3.1.1"
     "@bucketco/eslint-config": "workspace:^"
     "@bucketco/tsconfig": "workspace:^"
     "@testing-library/react": "npm:^15.0.7"


### PR DESCRIPTION
- Deprecate enabledCheck and configCheck event listeners in favour of just `check`.
- Publishes new patch version for browser and react sdks.