### PR TITLE
feat: fix node type, add stages, cleanup logs

### DIFF
--- a/packages/cli/commands/apps.ts
+++ b/packages/cli/commands/apps.ts
@@ -11,20 +11,20 @@ export const listAppsAction = async () => {
   const spinner = ora(`Loading apps from ${chalk.cyan(baseUrl)}...`).start();
   try {
     const apps = await listApps();
-    spinner.succeed(`Loaded apps from ${chalk.cyan(baseUrl)}`);
+    spinner.succeed(`Loaded apps from ${chalk.cyan(baseUrl)}.`);
     console.table(apps);
   } catch (error) {
-    spinner.fail("Failed to list apps");
+    spinner.fail("Failed to list apps.");
     void handleError(error, "Apps List");
   }
 };
 
 export function registerAppCommands(cli: Command) {
-  const appsCommand = new Command("apps").description("Manage apps");
+  const appsCommand = new Command("apps").description("Manage apps.");
 
   appsCommand
     .command("list")
-    .description("List all available apps")
+    .description("List all available apps.")
     .action(listAppsAction);
 
   cli.addCommand(appsCommand);

--- a/packages/cli/commands/auth.ts
+++ b/packages/cli/commands/auth.ts
@@ -14,7 +14,7 @@ export const loginAction = async () => {
     await authenticateUser(baseUrl);
     spinner.succeed(`Logged in to ${chalk.cyan(baseUrl)} successfully! 🎉`);
   } catch (error) {
-    spinner.fail("Login failed");
+    spinner.fail("Login failed.");
     void handleError(error, "Login");
   }
 };
@@ -26,13 +26,13 @@ export const logoutAction = async () => {
     await authStore.setToken(baseUrl, undefined);
     spinner.succeed("Logged out successfully! 👋");
   } catch (error) {
-    spinner.fail("Logout failed");
+    spinner.fail("Logout failed.");
     void handleError(error, "Logout");
   }
 };
 
 export function registerAuthCommands(cli: Command) {
-  cli.command("login").description("Login to Bucket").action(loginAction);
+  cli.command("login").description("Login to Bucket.").action(loginAction);
 
-  cli.command("logout").description("Logout from Bucket").action(logoutAction);
+  cli.command("logout").description("Logout from Bucket.").action(logoutAction);
 }

--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -53,12 +53,12 @@ export const initAction = async (args: InitArgs = {}) => {
         `Automatically selected app ${chalk.cyan(nonDemoApps[0].name)} (${chalk.cyan(appId)}).`,
       );
     } else {
+      const longestName = Math.max(...apps.map((app) => app.name.length));
       appId = await select({
         message: "Select an app",
         choices: apps.map((app) => ({
-          name: app.name,
+          name: `${app.name.padEnd(longestName, " ")}${app.demo ? " [Demo]" : ""}`,
           value: app.id,
-          description: app.demo ? "Demo" : undefined,
         })),
       });
     }

--- a/packages/cli/commands/init.ts
+++ b/packages/cli/commands/init.ts
@@ -33,9 +33,9 @@ export const initAction = async (args: InitArgs = {}) => {
     // Load apps
     spinner = ora(`Loading apps from ${chalk.cyan(baseUrl)}...`).start();
     apps = await listApps();
-    spinner.succeed(`Loaded apps from ${chalk.cyan(baseUrl)}`);
+    spinner.succeed(`Loaded apps from ${chalk.cyan(baseUrl)}.`);
   } catch (error) {
-    spinner?.fail("Loading apps failed");
+    spinner?.fail("Loading apps failed.");
     void handleError(error, "Initialization");
     return;
   }
@@ -50,9 +50,7 @@ export const initAction = async (args: InitArgs = {}) => {
     } else if (nonDemoApps.length === 1) {
       appId = nonDemoApps[0].id;
       console.log(
-        chalk.gray(
-          `Automatically selected app ${nonDemoApps[0].name} (${appId})`,
-        ),
+        `Automatically selected app ${chalk.cyan(nonDemoApps[0].name)} (${chalk.cyan(appId)}).`,
       );
     } else {
       appId = await select({
@@ -95,10 +93,10 @@ export const initAction = async (args: InitArgs = {}) => {
     spinner = ora("Creating configuration...").start();
     await configStore.saveConfigFile(args.overwrite);
     spinner.succeed(
-      `Configuration created at ${chalk.cyan(relative(process.cwd(), configStore.getConfigPath()!))}`,
+      `Configuration created at ${chalk.cyan(relative(process.cwd(), configStore.getConfigPath()!))}.`,
     );
   } catch (error) {
-    spinner?.fail("Configuration creation failed");
+    spinner?.fail("Configuration creation failed.");
     void handleError(error, "Initialization");
   }
 };
@@ -106,7 +104,7 @@ export const initAction = async (args: InitArgs = {}) => {
 export function registerInitCommand(cli: Command) {
   cli
     .command("init")
-    .description("Initialize a new Bucket configuration")
+    .description("Initialize a new Bucket configuration.")
     .addOption(overwriteOption)
     .action(initAction);
 }

--- a/packages/cli/commands/new.ts
+++ b/packages/cli/commands/new.ts
@@ -35,7 +35,7 @@ export function registerNewCommand(cli: Command) {
   cli
     .command("new")
     .description(
-      "Initialize the Bucket CLI, authenticates, and creates a new feature",
+      "Initialize the Bucket CLI, authenticates, and creates a new feature.",
     )
     .addOption(appIdOption)
     .addOption(keyFormatOption)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/cli",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "packageManager": "yarn@4.1.1",
   "description": "CLI for Bucket service",
   "main": "./dist/index.js",

--- a/packages/cli/services/features.ts
+++ b/packages/cli/services/features.ts
@@ -1,5 +1,7 @@
 import { authRequest } from "../utils/auth.js";
 
+import { Stage } from "./stages.js";
+
 export type RemoteConfigVariant = {
   key?: string;
   payload?: any;
@@ -17,6 +19,7 @@ export type Feature = {
   name: string;
   key: string;
   remoteConfigs: RemoteConfig[];
+  stage: Stage | null;
 };
 
 export type FeaturesResponse = {

--- a/packages/cli/services/stages.ts
+++ b/packages/cli/services/stages.ts
@@ -1,0 +1,16 @@
+import { authRequest } from "../utils/auth.js";
+
+export type Stage = {
+  id: string;
+  name: string;
+  order: number;
+};
+
+type StagesResponse = {
+  stages: Stage[];
+};
+
+export async function listStages(appId: string): Promise<Stage[]> {
+  const response = await authRequest<StagesResponse>(`/apps/${appId}/stages`);
+  return response.stages;
+}

--- a/packages/cli/utils/auth.ts
+++ b/packages/cli/utils/auth.ts
@@ -19,7 +19,7 @@ export async function authenticateUser(baseUrl: string) {
     let isResolved = false;
 
     const server = http.createServer(async (req, res) => {
-      const url = new URL(req.url ?? "/", "http://localhost");
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
       const headers = corsHeaders(baseUrl);
 
       // Ensure we don't process requests after resolution
@@ -63,8 +63,8 @@ export async function authenticateUser(baseUrl: string) {
     });
 
     const timeout = setTimeout(() => {
-      cleanupAndReject(new Error("Authentication timed out after 30 seconds"));
-    }, 30000);
+      cleanupAndReject(new Error("Authentication timed out after 60 seconds"));
+    }, 60000);
 
     function cleanupAndResolve(token: string) {
       if (isResolved) return;
@@ -94,9 +94,7 @@ export async function authenticateUser(baseUrl: string) {
     const address = server.address();
     if (address && typeof address === "object") {
       const port = address.port;
-      void open(loginUrl(baseUrl, port), {
-        newInstance: true,
-      });
+      void open(loginUrl(baseUrl, port));
     }
   });
 }

--- a/packages/cli/utils/gen.ts
+++ b/packages/cli/utils/gen.ts
@@ -1,6 +1,7 @@
 import { camelCase, kebabCase, pascalCase, snakeCase } from "change-case";
 
 import { Feature, RemoteConfig } from "../services/features.js";
+import { Stage } from "../services/stages.js";
 
 import { JSONToType } from "./json.js";
 
@@ -89,7 +90,11 @@ export function genRemoteConfig(remoteConfigs?: RemoteConfig[]) {
   );
 }
 
-export function genTypes(features: Feature[], format: GenFormat = "react") {
+export function genTypes(
+  features: Feature[],
+  stages: Stage[],
+  format: GenFormat = "react",
+) {
   const configDefs = new Map<string, { name: string; definition: string }>();
   features.forEach(({ key, name, remoteConfigs }) => {
     const definition = genRemoteConfig(remoteConfigs);
@@ -105,6 +110,11 @@ export function genTypes(features: Feature[], format: GenFormat = "react") {
 import "@bucketco/${format}-sdk";
 
 declare module "@bucketco/${format}-sdk" {
+  ${
+    stages.length
+      ? /* ts */ `export type Stage = ${stages.map(({ name }) => `"${name}"`).join(" | ")};\n`
+      : ""
+  }
   export interface Features {
 ${features
   .map(({ key }) => {

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -148,7 +148,7 @@ export type FeatureRemoteConfig =
  * Describes a feature
  */
 export interface Feature<
-  TConfig extends FeatureRemoteConfig | undefined = EmptyFeatureRemoteConfig,
+  TConfig extends FeatureType["config"] | undefined = EmptyFeatureRemoteConfig,
 > {
   /**
    * The key of the feature.
@@ -163,7 +163,11 @@ export interface Feature<
   /*
    * Optional user-defined configuration.
    */
-  config: TConfig extends undefined ? EmptyFeatureRemoteConfig : TConfig;
+  config: TConfig extends undefined
+    ? EmptyFeatureRemoteConfig
+    : TConfig & {
+        key: string;
+      };
 
   /**
    * Track feature usage in Bucket.


### PR DESCRIPTION
- Added stages export as a simple union `export type Stage = "Alpha" | "Beta";`.
- Fix node-sdk type to match react-sdk.
- Improved type gen logging.
- Made all logging more consistent.