### PR TITLE
feat: use new login scheme which supports Safari

### DIFF
--- a/packages/cli/commands/auth.ts
+++ b/packages/cli/commands/auth.ts
@@ -4,17 +4,17 @@ import ora from "ora";
 
 import { authStore } from "../stores/auth.js";
 import { configStore } from "../stores/config.js";
-import { authenticateUser } from "../utils/auth.js";
+import { waitForAccessToken } from "../utils/auth.js";
 import { handleError } from "../utils/errors.js";
 
 export const loginAction = async () => {
-  const baseUrl = configStore.getConfig("baseUrl");
-  const spinner = ora(`Logging in to ${chalk.cyan(baseUrl)}...`).start();
+  const { baseUrl, apiUrl } = configStore.getConfig();
+
   try {
-    await authenticateUser(baseUrl);
-    spinner.succeed(`Logged in to ${chalk.cyan(baseUrl)} successfully! 🎉`);
+    await waitForAccessToken(baseUrl, apiUrl);
+    console.log(`Logged in to ${chalk.cyan(baseUrl)} successfully! 🎉`);
   } catch (error) {
-    spinner.fail("Login failed.");
+    console.error("Login failed.");
     void handleError(error, "Login");
   }
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "packageManager": "yarn@4.1.1",
   "description": "CLI for Bucket service",
   "main": "./dist/index.js",

--- a/packages/cli/utils/auth.ts
+++ b/packages/cli/utils/auth.ts
@@ -6,11 +6,7 @@ import open from "open";
 import { authStore } from "../stores/auth.js";
 import { configStore } from "../stores/config.js";
 
-import { loginUrl } from "./constants.js";
-
-const successUrl = (baseUrl: string) => `${baseUrl}/cli-login/success`;
-const errorUrl = (baseUrl: string, error: string) =>
-  `${baseUrl}/cli-login/error?error=${error}`;
+import { errorUrl, loginUrl, successUrl } from "./path.js";
 
 interface waitForAccessToken {
   accessToken: string;
@@ -36,8 +32,8 @@ export async function waitForAccessToken(baseUrl: string, apiUrl: string) {
     .replace(/\//g, "_");
 
   const timeout = setTimeout(() => {
-    cleanupAndReject(new Error("Authentication timed out after 30 seconds"));
-  }, 30000);
+    cleanupAndReject(new Error("Authentication timed out after 60 seconds"));
+  }, 60000);
 
   function cleanupAndReject(error: Error) {
     cleanup();
@@ -59,9 +55,7 @@ export async function waitForAccessToken(baseUrl: string, apiUrl: string) {
       return;
     }
 
-    const fullUrl = new URL(`http://localhost${req.url}`);
-
-    const code = fullUrl.searchParams.get("code");
+    const code = url.searchParams.get("code");
 
     if (!code) {
       res.writeHead(400).end("Could not authenticate");

--- a/packages/cli/utils/auth.ts
+++ b/packages/cli/utils/auth.ts
@@ -1,4 +1,6 @@
+import crypto from "crypto";
 import http from "http";
+import chalk from "chalk";
 import open from "open";
 
 import { authStore } from "../stores/auth.js";
@@ -6,97 +8,121 @@ import { configStore } from "../stores/config.js";
 
 import { loginUrl } from "./constants.js";
 
-function corsHeaders(baseUrl: string): Record<string, string> {
-  return {
-    "Access-Control-Allow-Origin": baseUrl,
-    "Access-Control-Allow-Methods": "GET",
-    "Access-Control-Allow-Headers": "Authorization",
-  };
+const successUrl = (baseUrl: string) => `${baseUrl}/cli-login/success`;
+const errorUrl = (baseUrl: string, error: string) =>
+  `${baseUrl}/cli-login/error?error=${error}`;
+
+interface waitForAccessToken {
+  accessToken: string;
+  expiresAt: Date;
 }
 
-export async function authenticateUser(baseUrl: string) {
-  return new Promise<string>((resolve, reject) => {
-    let isResolved = false;
+export async function waitForAccessToken(baseUrl: string, apiUrl: string) {
+  let resolve: (args: waitForAccessToken) => void,
+    reject: (arg0: Error) => void;
+  const promise = new Promise<waitForAccessToken>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
 
-    const server = http.createServer(async (req, res) => {
-      const url = new URL(req.url ?? "/", "http://127.0.0.1");
-      const headers = corsHeaders(baseUrl);
+  // PCKE code verifier and challenge
+  const codeVerifier = crypto.randomUUID();
+  const codeChallenge = crypto
+    .createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
 
-      // Ensure we don't process requests after resolution
-      if (isResolved) {
-        res.writeHead(503, headers).end();
-        return;
-      }
+  const timeout = setTimeout(() => {
+    cleanupAndReject(new Error("Authentication timed out after 30 seconds"));
+  }, 30000);
 
-      if (url.pathname !== "/cli-login") {
-        res.writeHead(404).end("Invalid path");
-        cleanupAndReject(new Error("Could not authenticate: Invalid path"));
-        return;
-      }
+  function cleanupAndReject(error: Error) {
+    cleanup();
+    reject(error);
+  }
 
-      // Handle preflight request
-      if (req.method === "OPTIONS") {
-        res.writeHead(200, headers);
-        res.end();
-        return;
-      }
+  function cleanup() {
+    clearTimeout(timeout);
+    server.close();
+    server.closeAllConnections();
+  }
 
-      if (!req.headers.authorization?.startsWith("Bearer ")) {
-        res.writeHead(400, headers).end("Could not authenticate");
-        cleanupAndReject(new Error("Could not authenticate"));
-        return;
-      }
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
 
-      const token = req.headers.authorization.slice("Bearer ".length);
-      headers["Content-Type"] = "application/json";
-      res.writeHead(200, headers);
-      res.end(JSON.stringify({ result: "success" }));
+    if (url.pathname !== "/cli-login") {
+      res.writeHead(404).end("Invalid path");
+      cleanupAndReject(new Error("Could not authenticate: Invalid path"));
+      return;
+    }
 
-      try {
-        await authStore.setToken(baseUrl, token);
-        cleanupAndResolve(token);
-      } catch (error) {
-        cleanupAndReject(
-          error instanceof Error ? error : new Error("Failed to store token"),
-        );
-      }
+    const fullUrl = new URL(`http://localhost${req.url}`);
+
+    const code = fullUrl.searchParams.get("code");
+
+    if (!code) {
+      res.writeHead(400).end("Could not authenticate");
+      cleanupAndReject(new Error("Could not authenticate: no code provided"));
+      return;
+    }
+
+    const response = await fetch(`${apiUrl}/oauth/cli/access-token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        code,
+        codeVerifier,
+      }),
     });
 
-    const timeout = setTimeout(() => {
-      cleanupAndReject(new Error("Authentication timed out after 60 seconds"));
-    }, 60000);
-
-    function cleanupAndResolve(token: string) {
-      if (isResolved) return;
-      isResolved = true;
-      cleanup();
-      resolve(token);
+    if (!response.ok) {
+      res
+        .writeHead(302, {
+          location: errorUrl(
+            baseUrl,
+            "Could not authenticate: Unable to fetch access token",
+          ),
+        })
+        .end("Could not authenticate");
+      cleanupAndReject(new Error("Could not authenticate"));
+      return;
     }
+    res
+      .writeHead(302, {
+        location: successUrl(baseUrl),
+      })
+      .end("Authentication successful");
 
-    function cleanupAndReject(error: Error) {
-      if (isResolved) return;
-      isResolved = true;
-      cleanup();
-      reject(error);
-    }
+    const jsonResponse = await response.json();
 
-    function cleanup() {
-      clearTimeout(timeout);
-      server.close();
-      // Force-close any remaining connections
-      server.getConnections((err, count) => {
-        if (err || count === 0) return;
-        server.closeAllConnections();
-      });
-    }
-
-    server.listen();
-    const address = server.address();
-    if (address && typeof address === "object") {
-      const port = address.port;
-      void open(loginUrl(baseUrl, port));
-    }
+    cleanup();
+    resolve({
+      accessToken: jsonResponse.accessToken,
+      expiresAt: new Date(jsonResponse.expiresAt),
+    });
   });
+
+  server.listen();
+  const address = server.address();
+  if (address == null || typeof address !== "object") {
+    throw new Error("Could not start server");
+  }
+
+  const port = address.port;
+  const browserUrl = loginUrl(apiUrl, port, codeChallenge);
+
+  console.log(
+    `Opened web browser to facilitate login: ${chalk.cyan(browserUrl)}`,
+  );
+
+  void open(browserUrl);
+
+  return promise;
 }
 
 export async function authRequest<T = Record<string, unknown>>(
@@ -110,7 +136,8 @@ export async function authRequest<T = Record<string, unknown>>(
   const token = authStore.getToken(baseUrl);
 
   if (!token) {
-    await authenticateUser(baseUrl);
+    const accessToken = await waitForAccessToken(baseUrl, apiUrl);
+    await authStore.setToken(baseUrl, accessToken.accessToken);
     return authRequest(url, options);
   }
 
@@ -133,7 +160,7 @@ export async function authRequest<T = Record<string, unknown>>(
     if (response.status === 401) {
       await authStore.setToken(baseUrl, undefined);
       if (retryCount < 1) {
-        await authenticateUser(baseUrl);
+        await waitForAccessToken(baseUrl, apiUrl);
         return authRequest(url, options, retryCount + 1);
       }
     }

--- a/packages/cli/utils/auth.ts
+++ b/packages/cli/utils/auth.ts
@@ -134,7 +134,6 @@ export async function authRequest<T = Record<string, unknown>>(
     await authStore.setToken(baseUrl, accessToken.accessToken);
     return authRequest(url, options);
   }
-
   const resolvedUrl = new URL(`${apiUrl}/${url}`);
   if (options?.params) {
     Object.entries(options.params).forEach(([key, value]) => {

--- a/packages/cli/utils/constants.ts
+++ b/packages/cli/utils/constants.ts
@@ -14,6 +14,9 @@ export const DEFAULT_TYPES_OUTPUT = join("gen", "features.ts");
 
 export const chalkBrand = chalk.hex("#847CFB");
 
-export const loginUrl = (baseUrl: string, localPort: number) =>
-  `${baseUrl}/login?redirect_url=` +
-  encodeURIComponent("/cli-login?port=" + localPort);
+export const loginUrl = (
+  baseUrl: string,
+  localPort: number,
+  codeChallenge: string,
+) =>
+  `${baseUrl}/oauth/cli/authorize?port=${localPort}&codeChallenge=${codeChallenge}`;

--- a/packages/cli/utils/constants.ts
+++ b/packages/cli/utils/constants.ts
@@ -10,10 +10,3 @@ export const SCHEMA_URL = `https://unpkg.com/@bucketco/cli@latest/schema.json`;
 export const DEFAULT_BASE_URL = "https://app.bucket.co";
 export const DEFAULT_API_URL = `${DEFAULT_BASE_URL}/api`;
 export const DEFAULT_TYPES_OUTPUT = join("gen", "features.d.ts");
-
-export const loginUrl = (
-  baseUrl: string,
-  localPort: number,
-  codeChallenge: string,
-) =>
-  `${baseUrl}/oauth/cli/authorize?port=${localPort}&codeChallenge=${codeChallenge}`;

--- a/packages/cli/utils/path.ts
+++ b/packages/cli/utils/path.ts
@@ -1,3 +1,14 @@
 export function stripTrailingSlash<T extends string | undefined>(str: T): T {
   return str?.endsWith("/") ? (str.slice(0, -1) as T) : str;
 }
+
+export const successUrl = (baseUrl: string) => `${baseUrl}/cli-login/success`;
+export const errorUrl = (baseUrl: string, error: string) =>
+  `${baseUrl}/cli-login/error?error=${error}`;
+
+export const loginUrl = (
+  baseUrl: string,
+  localPort: number,
+  codeChallenge: string,
+) =>
+  `${baseUrl}/oauth/cli/authorize?port=${localPort}&codeChallenge=${codeChallenge}`;


### PR DESCRIPTION
This authentication flow does not use a fetch request to `http://localhost` but instead redirects there. We don't want to pass the actual access token along so it becomes part of the browser history. Instead we supple a code which is then exchanged for the actual access token through a new API endpoint in the backend.

This starts to look very much like a standard oauth flow. The key missing piece is come `client_id` parameters. I'm making the new server endpoints live under `/api/oauth/cli` so that when we do introduce propert oauth there will be no clashes.

I removed the spinner on login because it indicates that it's working when in reality it's waiting for you to do something. I'm also printing out the URL in case opening of the browser doesn't work. 