### PR TITLE
fix: `add` while flushing shouldn't send buffer again

### DIFF
--- a/packages/node-sdk/src/batch-buffer.ts
+++ b/packages/node-sdk/src/batch-buffer.ts
@@ -69,8 +69,11 @@ export default class BatchBuffer<T> {
       return;
     }
 
+    const flushingBuffer = this.buffer;
+    this.buffer = [];
+
     try {
-      await this.flushHandler(this.buffer);
+      await this.flushHandler(flushingBuffer);
 
       this.logger?.info("flushed buffered items", {
         count: this.buffer.length,
@@ -81,7 +84,5 @@ export default class BatchBuffer<T> {
         count: this.buffer.length,
       });
     }
-
-    this.buffer = [];
   }
 }

--- a/packages/node-sdk/test/batch-buffer.test.ts
+++ b/packages/node-sdk/test/batch-buffer.test.ts
@@ -147,6 +147,22 @@ describe("BatchBuffer", () => {
       );
     });
 
+    it("calling flush simultaneously should only flush data once", async () => {
+      let itemsFlushed = 0;
+      const buffer = new BatchBuffer({
+        flushHandler: async (items) => {
+          itemsFlushed += items.length;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          mockFlushHandler();
+        },
+        logger: mockLogger,
+      });
+
+      await buffer.add("item1");
+      await Promise.all([buffer.flush(), buffer.flush()]);
+      expect(itemsFlushed).toBe(1);
+    });
+
     it("should flush buffer", async () => {
       const buffer = new BatchBuffer({
         flushHandler: mockFlushHandler,


### PR DESCRIPTION
Adding to the buffer while the client was flushing would cause another flush of the same data to start.