### PR TITLE
feat: simplify types treating key and payload always as optional

### DIFF
--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -148,7 +148,7 @@ export type FeatureRemoteConfig =
  * Describes a feature
  */
 export interface Feature<
-  TConfig extends FeatureType["config"] | undefined = EmptyFeatureRemoteConfig,
+  TConfig extends FeatureType["config"] = EmptyFeatureRemoteConfig,
 > {
   /**
    * The key of the feature.
@@ -163,11 +163,11 @@ export interface Feature<
   /*
    * Optional user-defined configuration.
    */
-  config: TConfig extends undefined
-    ? EmptyFeatureRemoteConfig
-    : TConfig & {
+  config:
+    | ({
         key: string;
-      };
+      } & TConfig)
+    | EmptyFeatureRemoteConfig;
 
   /**
    * Track feature usage in Bucket.

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/react-sdk",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -62,7 +62,7 @@ export type FeatureRemoteConfig =
  * Describes a feature
  */
 export interface Feature<
-  TConfig extends FeatureType["config"] | undefined = EmptyFeatureRemoteConfig,
+  TConfig extends FeatureType["config"] = EmptyFeatureRemoteConfig,
 > {
   /**
    * The key of the feature.
@@ -82,11 +82,11 @@ export interface Feature<
   /*
    * Optional user-defined configuration.
    */
-  config: TConfig extends undefined
-    ? EmptyFeatureRemoteConfig
-    : TConfig & {
+  config:
+    | ({
         key: string;
-      };
+      } & TConfig)
+    | EmptyFeatureRemoteConfig;
 
   /**
    * Track feature usage in Bucket.


### PR DESCRIPTION
Utilizing [TypeScript intersection](https://github.com/microsoft/TypeScript/pull/31838) to simplify config types. Config keys and payload can now always be `undefined`.