### PR TITLE
fix(node-sdk): increase default `get` timeout to 10s, add 3 retries

### DIFF
--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/src/config.ts
+++ b/packages/node-sdk/src/config.ts
@@ -8,7 +8,7 @@ import { isObject, ok } from "./utils";
 export const API_BASE_URL = "https://front.bucket.co";
 export const SDK_VERSION_HEADER_NAME = "bucket-sdk-version";
 export const SDK_VERSION = `node-sdk/${version}`;
-export const API_TIMEOUT_MS = 5000;
+export const API_TIMEOUT_MS = 10000;
 export const END_FLUSH_TIMEOUT_MS = 5000;
 
 export const BUCKET_LOG_PREFIX = "[Bucket]";

--- a/packages/node-sdk/src/fetch-http-client.ts
+++ b/packages/node-sdk/src/fetch-http-client.ts
@@ -89,7 +89,7 @@ export async function withRetry<T>(
         baseDelay * Math.pow(2, attempt) * (0.8 + Math.random() * 0.4),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await new Promise((resolve) => setTimeout(resolve, delay).unref());
     }
   }
 

--- a/packages/node-sdk/src/fetch-http-client.ts
+++ b/packages/node-sdk/src/fetch-http-client.ts
@@ -13,6 +13,7 @@ const fetchClient: HttpClient = {
     url: string,
     headers: Record<string, string>,
     body: TBody,
+    timeoutMs: number = API_TIMEOUT_MS,
   ) => {
     ok(typeof url === "string" && url.length > 0, "URL must be a string");
     ok(typeof headers === "object", "Headers must be an object");
@@ -21,7 +22,7 @@ const fetchClient: HttpClient = {
       method: "post",
       headers,
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     const json = await response.json();
@@ -32,14 +33,18 @@ const fetchClient: HttpClient = {
     };
   },
 
-  get: async <TResponse>(url: string, headers: Record<string, string>) => {
+  get: async <TResponse>(
+    url: string,
+    headers: Record<string, string>,
+    timeoutMs: number = API_TIMEOUT_MS,
+  ) => {
     ok(typeof url === "string" && url.length > 0, "URL must be a string");
     ok(typeof headers === "object", "Headers must be an object");
 
     const response = await fetch(url, {
       method: "get",
       headers,
-      signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
 
     const json = await response.json();
@@ -50,5 +55,45 @@ const fetchClient: HttpClient = {
     };
   },
 };
+
+/**
+ * Implements exponential backoff retry logic for async functions.
+ *
+ * @param fn - The async function to retry.
+ * @param maxRetries - Maximum number of retry attempts.
+ * @param baseDelay - Base delay in milliseconds before retrying.
+ * @param maxDelay - Maximum delay in milliseconds.
+ * @returns The result of the function call or throws an error if all retries fail.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxRetries: number,
+  baseDelay: number,
+  maxDelay: number,
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === maxRetries) {
+        break;
+      }
+
+      // Calculate exponential backoff with jitter
+      const delay = Math.min(
+        maxDelay,
+        baseDelay * Math.pow(2, attempt) * (0.8 + Math.random() * 0.4),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
 
 export default fetchClient;

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -386,6 +386,7 @@ export interface HttpClient {
   get<TResponse>(
     url: string,
     headers: Record<string, string>,
+    timeoutMs: number,
   ): Promise<HttpClientResponse<TResponse>>;
 }
 
@@ -530,6 +531,18 @@ export type ClientOptions = {
    * The HTTP client to use for sending requests (optional). Default is the built-in fetch client.
    **/
   httpClient?: HttpClient;
+
+  /**
+   * The timeout in milliseconds for fetching feature targeting data (optional).
+   * Default is 10000 ms.
+   **/
+  fetchTimeoutMs?: number;
+
+  /**
+   * Number of times to retry fetching feature definitions (optional).
+   * Default is 3 times.
+   **/
+  featuresFetchRetries?: number;
 
   /**
    * The options for the batch buffer (optional).

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -15,6 +15,7 @@ import { evaluateFeatureRules } from "@bucketco/flag-evaluation";
 import { BoundBucketClient, BucketClient } from "../src";
 import {
   API_BASE_URL,
+  API_TIMEOUT_MS,
   BATCH_INTERVAL_MS,
   BATCH_MAX_SIZE,
   FEATURE_EVENT_RATE_LIMITER_WINDOW_SIZE_MS,
@@ -84,6 +85,7 @@ const validOptions: ClientOptions = {
   logger,
   httpClient,
   fallbackFeatures,
+  featuresFetchRetries: 2,
   batchOptions: {
     maxSize: 99,
     intervalMs: 100,
@@ -275,6 +277,7 @@ describe("BucketClient", () => {
           isEnabled: true,
         },
       });
+      expect(client["_config"].featuresFetchRetries).toBe(2);
     });
 
     it("should route messages to the supplied logger", () => {
@@ -970,6 +973,7 @@ describe("BucketClient", () => {
       expect(httpClient.get).toHaveBeenCalledWith(
         `https://api.example.com/features`,
         expectedHeaders,
+        API_TIMEOUT_MS,
       );
     });
   });
@@ -2291,6 +2295,7 @@ describe("BucketClient", () => {
       expect(httpClient.get).toHaveBeenCalledWith(
         "https://api.example.com/features/evaluated?context.other.custom=context&context.other.key=value&context.user.id=c1&context.company.id=u1",
         expectedHeaders,
+        API_TIMEOUT_MS,
       );
     });
 
@@ -2302,6 +2307,7 @@ describe("BucketClient", () => {
       expect(httpClient.get).toHaveBeenCalledWith(
         "https://api.example.com/features/evaluated?",
         expectedHeaders,
+        API_TIMEOUT_MS,
       );
     });
 
@@ -2373,6 +2379,7 @@ describe("BucketClient", () => {
       expect(httpClient.get).toHaveBeenCalledWith(
         "https://api.example.com/features/evaluated?context.other.custom=context&context.other.key=value&context.user.id=c1&context.company.id=u1&key=feature1",
         expectedHeaders,
+        API_TIMEOUT_MS,
       );
     });
 
@@ -2382,6 +2389,7 @@ describe("BucketClient", () => {
       expect(httpClient.get).toHaveBeenCalledWith(
         "https://api.example.com/features/evaluated?key=feature1",
         expectedHeaders,
+        API_TIMEOUT_MS,
       );
     });
 
@@ -2617,6 +2625,7 @@ describe("BoundBucketClient", () => {
       expect(httpClient.get).toHaveBeenCalledWith(
         "https://api.example.com/features/evaluated?context.user.id=user123&context.user.age=1&context.user.name=John&context.company.id=company123&context.company.employees=100&context.company.name=Acme+Inc.&context.other.custom=context&context.other.key=value",
         expectedHeaders,
+        API_TIMEOUT_MS,
       );
     });
 
@@ -2641,6 +2650,7 @@ describe("BoundBucketClient", () => {
       expect(httpClient.get).toHaveBeenCalledWith(
         "https://api.example.com/features/evaluated?context.user.id=user123&context.user.age=1&context.user.name=John&context.company.id=company123&context.company.employees=100&context.company.name=Acme+Inc.&context.other.custom=context&context.other.key=value&key=feature1",
         expectedHeaders,
+        API_TIMEOUT_MS,
       );
     });
   });


### PR DESCRIPTION
Our HTTP API responds to `/feature` requests in less than 5ms, but there are cases where the network on the client could be dodgy or there's otherwise some delay. Especially when the program is just starting up this is problematic because the NodeSDK will use the fallback flags which for the most part are empty.

This introduces a configurable timeout and default the timeout to 10s instead of the existing 5s. It also adds an exponential retry which is set to 3 tries by default. 