### PR TITLE
fix: skip bootstrap for specific commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "packageManager": "yarn@4.1.1",
   "description": "CLI for Bucket service",
   "main": "./dist/index.js",

--- a/packages/cli/utils/commander.ts
+++ b/packages/cli/utils/commander.ts
@@ -1,0 +1,12 @@
+import { Command } from "commander";
+
+export function commandName(command: Command) {
+  if (
+    command.parent &&
+    command.parent.name() &&
+    command.parent.name() !== "index"
+  ) {
+    return `${command.parent.name()} ${command.name()}`;
+  }
+  return command.name();
+}

--- a/packages/cli/utils/commander.ts
+++ b/packages/cli/utils/commander.ts
@@ -1,12 +1,11 @@
 import { Command } from "commander";
 
 export function commandName(command: Command) {
-  if (
-    command.parent &&
-    command.parent.name() &&
-    command.parent.name() !== "index"
-  ) {
-    return `${command.parent.name()} ${command.name()}`;
+  if (command.parent) {
+    const parentName = command.parent.name();
+    if (parentName && parentName !== "index") {
+      return `${parentName} ${command.name()}`;
+    }
   }
   return command.name();
 }


### PR DESCRIPTION
This pull request introduces several changes to the CLI package to improve command handling and versioning. The key updates include adding a utility function for command names, skipping bootstrap for specific commands, and updating the package version.

### Command handling improvements:

* [`packages/cli/index.ts`](diffhunk://#diff-ce752ce36be970cbc0110dae521e82462b9ee7dbca55f45b51648c82998da18dR17-R23): Added `commandName` import and defined `skipBootstrapCommands` to skip bootstrapping for certain commands. Updated `preAction` hook to check command names and conditionally skip bootstrapping. [[1]](diffhunk://#diff-ce752ce36be970cbc0110dae521e82462b9ee7dbca55f45b51648c82998da18dR17-R23) [[2]](diffhunk://#diff-ce752ce36be970cbc0110dae521e82462b9ee7dbca55f45b51648c82998da18dL38-R41) [[3]](diffhunk://#diff-ce752ce36be970cbc0110dae521e82462b9ee7dbca55f45b51648c82998da18dR52-R55) [[4]](diffhunk://#diff-ce752ce36be970cbc0110dae521e82462b9ee7dbca55f45b51648c82998da18dL57-R70)
* [`packages/cli/utils/commander.ts`](diffhunk://#diff-9c08f2138134021105cbc82cfc742dcaff35b63938a38c9434298d200822e3afR1-R12): Added a new utility function `commandName` to construct full command names for nested commands.

### Version update:

* [`packages/cli/package.json`](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L3-R3): Updated the package version from `0.5.0` to `0.5.1`.