### PR TITLE
fix: Improve logging when not initialized

### DIFF
--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -127,11 +127,15 @@ export class BucketClient {
    */
   public readonly logger: Logger;
 
+  private initializationFinished = false;
   private _initialize = once(async () => {
     if (!this._config.offline) {
       await this.featuresCache.refresh();
     }
-    this.logger.info("Bucket initialized");
+    this.logger.info(
+      "Bucket initialized" + (this._config.offline ? " (offline mode)" : ""),
+    );
+    this.initializationFinished = true;
   });
 
   /**
@@ -219,7 +223,10 @@ export class BucketClient {
 
     const offline = config.offline ?? process.env.NODE_ENV === "test";
     if (!offline) {
-      ok(typeof config.secretKey === "string", "secretKey must be a string");
+      ok(
+        typeof config.secretKey === "string",
+        "secretKey must be a string, or set offline=true",
+      );
       ok(config.secretKey.length > 22, "invalid secretKey specified");
     }
 
@@ -957,6 +964,10 @@ export class BucketClient {
   ): Record<string, RawFeature> {
     checkContextWithTracking(options);
 
+    if (!this.initializationFinished) {
+      this.logger.error("BucketClient is not initialized yet.");
+    }
+
     void this.syncContext(options);
     let featureDefinitions: FeaturesAPIResponse["features"];
 
@@ -966,7 +977,7 @@ export class BucketClient {
       const fetchedFeatures = this.featuresCache.get();
       if (!fetchedFeatures) {
         this.logger.warn(
-          "failed to use feature definitions, there are none cached yet. Using fallback features.",
+          "no feature definitions available, using fallback features.",
         );
         return this._config.fallbackFeatures || {};
       }

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -965,7 +965,7 @@ export class BucketClient {
     checkContextWithTracking(options);
 
     if (!this.initializationFinished) {
-      this.logger.error("BucketClient is not initialized yet.");
+      this.logger.error("getFeature(s): BucketClient is not initialized yet.");
     }
 
     void this.syncContext(options);

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -2055,7 +2055,7 @@ describe("BucketClient", () => {
 
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringMatching(
-          "failed to use feature definitions, there are none cached yet. Using fallback features.",
+          "no feature definitions available, using fallback features",
         ),
       );
 


### PR DESCRIPTION
Correctly initializing the BucketClient can be a bit tricky. This should complain more loudly when it happens.

I considered and rejected the idea of throwing an error when this happens because incorrectly constructed initialization code may only break under high concurrency and thus only show up in production which could cause down time if we throw.