### PR TITLE
Update README with Gitbook tabs in installtion section

### DIFF
--- a/packages/node-sdk/README.md
+++ b/packages/node-sdk/README.md
@@ -6,9 +6,39 @@ Bucket supports feature toggling, tracking feature usage, collecting feedback on
 
 ## Installation
 
-Install using `yarn` or `npm` with:
+Install using your favourite package manager:
 
-> `yarn add -s @bucketco/node-sdk` or `npm install -s @bucketco/node-sdk`.
+{% tabs %}
+{% tab title="npm" %}
+```sh
+npm i @bucketco/node-sdk
+```
+{% endtab %}
+
+{% tab title="yarn" %}
+```sh
+yarn add @bucketco/node-sdk
+```
+{% endtab %}
+
+{% tab title="bun" %}
+```sh
+bun add @bucketco/node-sdk
+```
+{% endtab %}
+
+{% tab title="pnpm" %}
+```sh
+pnpm add @bucketco/node-sdk
+```
+{% endtab %}
+
+{% tab title="deno" %}
+```sh
+deno add npm:@bucketco/node-sdk
+```
+{% endtab %}
+{% endtabs %}
 
 Other supported languages/frameworks are in the [Supported languages](https://docs.bucket.co/quickstart/supported-languages) documentation pages.
 


### PR DESCRIPTION
In the installation section on https://docs.bucket.co/supported-languages/node-sdk we should show how to install the SDK using various different package managers.

This change uses the Gitbook-specific markdown for tabs to achieve this (as [seen here](https://github.com/bucketco/docs/commit/006842ab34b645055a6a191b6ab31262c51d05f0))

<img width="874" alt="image" src="https://github.com/user-attachments/assets/5cb2fb03-edd5-4a70-9817-4e2cab2f89d6" />
