### PR TITLE
Fix numeric comparison in evaluate bug

### DIFF
--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -304,7 +304,7 @@ export function evaluate(
         );
         return false;
       }
-      return fieldValue > value;
+      return Number(fieldValue) > Number(value);
     case "LT":
       if (isNaN(Number(fieldValue)) || isNaN(Number(value))) {
         console.error(
@@ -312,7 +312,7 @@ export function evaluate(
         );
         return false;
       }
-      return fieldValue < value;
+      return Number(fieldValue) < Number(value);
     case "AFTER":
     case "BEFORE": {
       // more/less than `value` days ago

--- a/packages/flag-evaluation/test/index.test.ts
+++ b/packages/flag-evaluation/test/index.test.ts
@@ -381,10 +381,14 @@ describe("operator evaluation", () => {
     ["value", "GT", "value", false],
     ["value", "GT", "0", false],
     ["1", "GT", "0", true],
+    ["2", "GT", "10", false],
+    ["10", "GT", "2", true],
 
     ["value", "LT", "value", false],
     ["value", "LT", "0", false],
     ["0", "LT", "1", true],
+    ["2", "LT", "10", true],
+    ["10", "LT", "2", false],
 
     ["start VALUE end", "CONTAINS", "value", true],
     ["alue", "CONTAINS", "value", false],


### PR DESCRIPTION
In local evaluation for the Node SDK:

Fix numeric comparison for GT/LT operators where casting strings to numbers wasn't being done correctly happen.
That could result in situations where "2" > "10" == true

Added test case

Note: replaces https://github.com/bucketco/bucket-javascript-sdk/pull/424 which was created from another remote (forked repo) which meant that GH actions build and test wouldn't run