### PR TITLE
docs(vue-sdk): simplify getting started docs

### DIFF
--- a/packages/vue-sdk/README.md
+++ b/packages/vue-sdk/README.md
@@ -46,23 +46,6 @@ const huddle = useFeature("huddle");
 <template>
   <div v-if="huddle.isEnabled">
     <button @click="huddle.track()">Start huddle!</button>
-    <button
-      @click="
-        (e) =>
-          huddle.requestFeedback({
-            title:
-              huddle.config.payload?.question ??
-              'How do you like the Huddles feature?',
-            position: {
-              type: 'POPOVER',
-              anchor: e.currentTarget as HTMLElement,
-            },
-          })
-      "
-    >
-      Give feedback!
-    </button>
-  </div>
 </template>
 ```
 
@@ -128,24 +111,6 @@ The `<BucketProvider>` initializes the Bucket SDK, fetches features and starts l
 - `company`, `user` and `otherContext` make up the _context_ that is used to determine if a feature is enabled or not. `company` and `user` contexts are automatically transmitted to Bucket servers so the Bucket app can show you which companies have access to which features etc.
   > [!Note]
   > If you specify `company` and/or `user` they must have at least the `id` property, otherwise they will be ignored in their entirety. You should also supply anything additional you want to be able to evaluate feature targeting against,
-- `fallbackFeatures`: A list of strings which specify which features to consider enabled if the SDK is unable to fetch features. Can be provided in two formats:
-
-  ```ts
-  // Simple array of feature keys
-  fallbackFeatures={["feature1", "feature2"]}
-
-  // Or with configuration overrides
-  fallbackFeatures: {
-      "feature1": true,  // just enable the feature
-      "feature2": {      // enable with configuration
-        key: "variant-a",
-        payload: {
-          limit: 100,
-          mode: "test"
-        }
-      }
-  }
-  ```
 
 - `timeoutMs`: Timeout in milliseconds when fetching features from the server,
 - `staleWhileRevalidate`: If set to `true`, stale features will be returned while refetching features in the background,
@@ -216,6 +181,8 @@ const huddle = useFeature("huddle");
   </div>
 </template>
 ```
+
+See the reference docs for details.
 
 ### `useTrack()`
 


### PR DESCRIPTION
- Simplify getting started example
- Remove fallback features as they only serve to make folks confused and they are not really being used.