### PR TITLE
chore(browser-sdk): bump version to 3.3.0 and update dependencies

### DIFF
--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -109,6 +109,7 @@ type Configuration = {
   staleWhileRevalidate?: boolean; // Revalidate in the background when cached features turn stale to avoid latency in the UI (default: false)
   staleTimeMs?: number; // at initialization time features are loaded from the cache unless they have gone stale. Defaults to 0 which means the cache is disabled. Increase this in the case of a non-SPA
   expireTimeMs?: number; // In case we're unable to fetch features from Bucket, cached/stale features will be used instead until they expire after `expireTimeMs`. Default is 30 days
+  offline?: boolean; // Use the SDK in offline mode. Offline mode is useful during testing and local development
 };
 ```
 

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/browser-sdk",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "packageManager": "yarn@4.1.1",
   "license": "MIT",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -683,7 +683,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bucketco/browser-sdk@npm:3.2.0, @bucketco/browser-sdk@workspace:packages/browser-sdk":
+"@bucketco/browser-sdk@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@bucketco/browser-sdk@npm:3.2.0"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.6.8"
+    canonical-json: "npm:^0.0.4"
+    js-cookie: "npm:^3.0.5"
+    preact: "npm:^10.22.1"
+  checksum: 10c0/4663b213f24a1ba7f2878751606cd32752c477ca192fda5a264c6a27d4c6a2db9e4f3a5422bf45bb8ba6c24c2b5249def19f425243d3d754fde0d92231f35562
+  languageName: node
+  linkType: hard
+
+"@bucketco/browser-sdk@workspace:packages/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/browser-sdk@workspace:packages/browser-sdk"
   dependencies:


### PR DESCRIPTION
- Updated the version of the browser SDK to 3.3.0 in package.json.
- Adjusted yarn.lock to reflect the new version and its dependencies.
- Added documentation for the new `offline` option in README.md to enhance testing capabilities.