### PR TITLE
feat: allow disabling "evaluate" event generation

### DIFF
--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -123,6 +123,7 @@ export class BucketClient {
     fallbackFeatures?: Record<keyof TypedFeatures, RawFeature>;
     featureOverrides: FeatureOverridesFn;
     offline: boolean;
+    emitEvaluationEvents: boolean;
     configFile?: string;
     featuresFetchRetries: number;
     fetchTimeoutMs: number;
@@ -302,6 +303,7 @@ export class BucketClient {
 
     this._config = {
       offline,
+      emitEvaluationEvents: config.emitEvaluationEvents ?? true,
       apiBaseUrl: (config.apiBaseUrl ?? config.host) || API_BASE_URL,
       headers: {
         "Content-Type": "application/json",
@@ -905,6 +907,13 @@ export class BucketClient {
     ).toString();
 
     if (this._config.offline) {
+      return;
+    }
+
+    if (
+      !this._config.emitEvaluationEvents &&
+      (event.action === "evaluate" || event.action === "evaluate-config")
+    ) {
       return;
     }
 

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -645,6 +645,11 @@ export type ClientOptions = {
   offline?: boolean;
 
   /**
+   * If set to `false`, no evaluation events will be emitted.
+   */
+  emitEvaluationEvents?: boolean;
+
+  /**
    * The path to the config file. If supplied, the config file will be loaded.
    * Defaults to `bucket.json` when NODE_ENV is not production. Can also be
    * set through the environment variable BUCKET_CONFIG_FILE.

--- a/packages/openfeature-node-provider/package.json
+++ b/packages/openfeature-node-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/openfeature-node-provider",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -50,7 +50,7 @@
     "vitest": "~1.6.0"
   },
   "dependencies": {
-    "@bucketco/node-sdk": "1.9.1"
+    "@bucketco/node-sdk": "1.9.2"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.16.1"

--- a/packages/openfeature-node-provider/package.json
+++ b/packages/openfeature-node-provider/package.json
@@ -50,7 +50,7 @@
     "vitest": "~1.6.0"
   },
   "dependencies": {
-    "@bucketco/node-sdk": "1.8.4"
+    "@bucketco/node-sdk": "1.9.1"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,16 +795,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bucketco/node-sdk@npm:1.8.4":
-  version: 1.8.4
-  resolution: "@bucketco/node-sdk@npm:1.8.4"
-  dependencies:
-    "@bucketco/flag-evaluation": "npm:0.1.4"
-  checksum: 10c0/f5270915b61526f69f7dbd37b41edf0f130a4a008730f20baf00bbbf49c0a2e3e190a56d35a9451d5645e6da4d874f5d0d555f378596440cccb10306c4362003
-  languageName: node
-  linkType: hard
-
-"@bucketco/node-sdk@workspace:packages/node-sdk":
+"@bucketco/node-sdk@npm:1.9.1, @bucketco/node-sdk@workspace:packages/node-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/node-sdk@workspace:packages/node-sdk"
   dependencies:
@@ -854,7 +845,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:~7.24.7"
     "@bucketco/eslint-config": "npm:~0.0.2"
-    "@bucketco/node-sdk": "npm:1.8.4"
+    "@bucketco/node-sdk": "npm:1.9.1"
     "@bucketco/tsconfig": "npm:~0.0.2"
     "@openfeature/core": "npm:^1.5.0"
     "@openfeature/server-sdk": "npm:>=1.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,7 +786,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bucketco/node-sdk@npm:1.9.1, @bucketco/node-sdk@workspace:packages/node-sdk":
+"@bucketco/node-sdk@npm:1.9.2, @bucketco/node-sdk@workspace:packages/node-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/node-sdk@workspace:packages/node-sdk"
   dependencies:
@@ -836,7 +836,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:~7.24.7"
     "@bucketco/eslint-config": "npm:~0.0.2"
-    "@bucketco/node-sdk": "npm:1.9.1"
+    "@bucketco/node-sdk": "npm:1.9.2"
     "@bucketco/tsconfig": "npm:~0.0.2"
     "@openfeature/core": "npm:^1.5.0"
     "@openfeature/server-sdk": "npm:>=1.16.1"


### PR DESCRIPTION
This PR adds a new `emitEvaluationEvents` option (default: `true`). When set to`false`, the node SDK will not generate `evaluate` and `evaluate-config` events.