### PR TITLE
feat: add new context filter operators

### DIFF
--- a/packages/flag-evaluation/package.json
+++ b/packages/flag-evaluation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/flag-evaluation",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -344,15 +344,19 @@ export function evaluate(
         ? fieldValueDate > daysAgo.getTime()
         : fieldValueDate < daysAgo.getTime();
     }
-    case "DATE_AFTER": {
-      const fieldValueDate = new Date(fieldValue).getTime();
-      const valueDate = new Date(value).getTime();
-      return fieldValueDate >= valueDate;
-    }
+    case "DATE_AFTER":
     case "DATE_BEFORE": {
       const fieldValueDate = new Date(fieldValue).getTime();
       const valueDate = new Date(value).getTime();
-      return fieldValueDate <= valueDate;
+      if (isNaN(fieldValueDate) || isNaN(valueDate)) {
+        console.error(
+          `${operator} operator requires valid date values: ${fieldValue}, ${value}`,
+        );
+        return false;
+      }
+      return operator === "DATE_AFTER"
+        ? fieldValueDate >= valueDate
+        : fieldValueDate <= valueDate;
     }
     case "SET":
       return fieldValue !== "";

--- a/packages/flag-evaluation/src/index.ts
+++ b/packages/flag-evaluation/src/index.ts
@@ -85,6 +85,8 @@ type ContextFilterOperator =
   | "LT"
   | "AFTER"
   | "BEFORE"
+  | "DATE_AFTER"
+  | "DATE_BEFORE"
   | "SET"
   | "NOT_SET"
   | "IS_TRUE"
@@ -341,6 +343,16 @@ export function evaluate(
       return operator === "AFTER"
         ? fieldValueDate > daysAgo.getTime()
         : fieldValueDate < daysAgo.getTime();
+    }
+    case "DATE_AFTER": {
+      const fieldValueDate = new Date(fieldValue).getTime();
+      const valueDate = new Date(value).getTime();
+      return fieldValueDate >= valueDate;
+    }
+    case "DATE_BEFORE": {
+      const fieldValueDate = new Date(fieldValue).getTime();
+      const valueDate = new Date(value).getTime();
+      return fieldValueDate <= valueDate;
     }
     case "SET":
       return fieldValue !== "";

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -44,6 +44,6 @@
     "vitest": "~1.6.0"
   },
   "dependencies": {
-    "@bucketco/flag-evaluation": "0.1.4"
+    "@bucketco/flag-evaluation": "0.2.0"
   }
 }

--- a/packages/openfeature-node-provider/package.json
+++ b/packages/openfeature-node-provider/package.json
@@ -50,7 +50,7 @@
     "vitest": "~1.6.0"
   },
   "dependencies": {
-    "@bucketco/node-sdk": "1.8.4"
+    "@bucketco/node-sdk": "1.9.0"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -770,16 +770,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bucketco/flag-evaluation@npm:0.1.4":
-  version: 0.1.4
-  resolution: "@bucketco/flag-evaluation@npm:0.1.4"
-  dependencies:
-    js-sha256: "npm:0.11.0"
-  checksum: 10c0/d1f0513a3167d1c4d2a3caf782072f949f508760d77be2c6d5957f5a92d76aaf70467c1d923591c6663a6dcbe01f4d476e46eb501834231ae3d4f28ecff6640c
-  languageName: node
-  linkType: hard
-
-"@bucketco/flag-evaluation@workspace:packages/flag-evaluation":
+"@bucketco/flag-evaluation@npm:0.2.0, @bucketco/flag-evaluation@workspace:packages/flag-evaluation":
   version: 0.0.0-use.local
   resolution: "@bucketco/flag-evaluation@workspace:packages/flag-evaluation"
   dependencies:
@@ -795,22 +786,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bucketco/node-sdk@npm:1.8.4":
-  version: 1.8.4
-  resolution: "@bucketco/node-sdk@npm:1.8.4"
-  dependencies:
-    "@bucketco/flag-evaluation": "npm:0.1.4"
-  checksum: 10c0/f5270915b61526f69f7dbd37b41edf0f130a4a008730f20baf00bbbf49c0a2e3e190a56d35a9451d5645e6da4d874f5d0d555f378596440cccb10306c4362003
-  languageName: node
-  linkType: hard
-
-"@bucketco/node-sdk@workspace:packages/node-sdk":
+"@bucketco/node-sdk@npm:1.9.0, @bucketco/node-sdk@workspace:packages/node-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/node-sdk@workspace:packages/node-sdk"
   dependencies:
     "@babel/core": "npm:~7.24.7"
     "@bucketco/eslint-config": "npm:~0.0.2"
-    "@bucketco/flag-evaluation": "npm:0.1.4"
+    "@bucketco/flag-evaluation": "npm:0.2.0"
     "@bucketco/tsconfig": "npm:~0.0.2"
     "@types/node": "npm:^22.12.0"
     "@vitest/coverage-v8": "npm:~1.6.0"
@@ -854,7 +836,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:~7.24.7"
     "@bucketco/eslint-config": "npm:~0.0.2"
-    "@bucketco/node-sdk": "npm:1.8.4"
+    "@bucketco/node-sdk": "npm:1.9.0"
     "@bucketco/tsconfig": "npm:~0.0.2"
     "@openfeature/core": "npm:^1.5.0"
     "@openfeature/server-sdk": "npm:>=1.16.1"


### PR DESCRIPTION
- Bumped version of `@bucketco/flag-evaluation` to 0.2.0 and added new context filter operators: `DATE_AFTER` and `DATE_BEFORE`.
- Updated `@bucketco/node-sdk` to 1.9.0 to reflect the new version of `@bucketco/flag-evaluation`.
- Updated `@bucketco/openfeature-node-provider` to use the latest `@bucketco/node-sdk` version.