### PR TITLE
fix(node-sdk): avoid sending "check"'s when using getFeatures

### DIFF
--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketco/node-sdk",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/node-sdk/src/client.ts
+++ b/packages/node-sdk/src/client.ts
@@ -666,14 +666,17 @@ export class BucketClient {
     const features = this._getFeatures(options);
     const feature = features[key];
 
-    return this._wrapRawFeature(options, {
-      key,
-      isEnabled: feature?.isEnabled ?? false,
-      targetingVersion: feature?.targetingVersion,
-      config: feature?.config,
-      ruleEvaluationResults: feature?.ruleEvaluationResults,
-      missingContextFields: feature?.missingContextFields,
-    });
+    return this._wrapRawFeature(
+      { ...options, enableChecks: true },
+      {
+        key,
+        isEnabled: feature?.isEnabled ?? false,
+        targetingVersion: feature?.targetingVersion,
+        config: feature?.config,
+        ruleEvaluationResults: feature?.ruleEvaluationResults,
+        missingContextFields: feature?.missingContextFields,
+      },
+    );
   }
 
   /**
@@ -1199,7 +1202,11 @@ export class BucketClient {
   }
 
   private _wrapRawFeature<TKey extends keyof TypedFeatures>(
-    { enableTracking, ...context }: { enableTracking: boolean } & Context,
+    {
+      enableTracking,
+      enableChecks = false,
+      ...context
+    }: { enableTracking: boolean; enableChecks?: boolean } & Context,
     { config, ...feature }: RawFeature,
   ): TypedFeatures[TKey] {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -1211,7 +1218,7 @@ export class BucketClient {
 
     return {
       get isEnabled() {
-        if (enableTracking) {
+        if (enableTracking && enableChecks) {
           void client
             .sendFeatureEvent({
               action: "check",
@@ -1232,7 +1239,7 @@ export class BucketClient {
         return feature.isEnabled;
       },
       get config() {
-        if (enableTracking) {
+        if (enableTracking && enableChecks) {
           void client
             .sendFeatureEvent({
               action: "check-config",

--- a/packages/node-sdk/test/client.test.ts
+++ b/packages/node-sdk/test/client.test.ts
@@ -1646,7 +1646,7 @@ describe("BucketClient", () => {
       expect(events).toStrictEqual([]);
     });
 
-    it("`isEnabled` sends `check` event", async () => {
+    it("`isEnabled` does not send `check` event", async () => {
       const context = {
         company,
         user,
@@ -1665,21 +1665,10 @@ describe("BucketClient", () => {
         .flatMap((call) => call[2])
         .filter((e) => e.action === "check");
 
-      expect(checkEvents).toStrictEqual([
-        {
-          type: "feature-flag-event",
-          action: "check",
-          key: "feature1",
-          targetingVersion: 1,
-          evalResult: true,
-          evalContext: context,
-          evalRuleResults: [true],
-          evalMissingFields: [],
-        },
-      ]);
+      expect(checkEvents).toStrictEqual([]);
     });
 
-    it("`config` sends `check` event", async () => {
+    it("`config` does not send `check` event", async () => {
       const context = {
         company,
         user,
@@ -1690,7 +1679,7 @@ describe("BucketClient", () => {
       await client.initialize();
       const feature = client.getFeatures(context);
 
-      // trigger `check` event
+      // attempt to trigger `check` event
       expect(feature.feature1.config).toBeDefined();
 
       await client.flush();
@@ -1699,23 +1688,7 @@ describe("BucketClient", () => {
         .flatMap((call) => call[2])
         .filter((e) => e.action === "check-config");
 
-      expect(checkEvents).toStrictEqual([
-        {
-          type: "feature-flag-event",
-          action: "check-config",
-          key: "feature1",
-          evalResult: {
-            key: "config-1",
-            payload: {
-              something: "else",
-            },
-          },
-          targetingVersion: 1,
-          evalContext: context,
-          evalRuleResults: [true],
-          evalMissingFields: [],
-        },
-      ]);
+      expect(checkEvents).toStrictEqual([]);
     });
 
     it("sends company/user events", async () => {

--- a/packages/openfeature-node-provider/package.json
+++ b/packages/openfeature-node-provider/package.json
@@ -50,7 +50,7 @@
     "vitest": "~1.6.0"
   },
   "dependencies": {
-    "@bucketco/node-sdk": "1.9.2"
+    "@bucketco/node-sdk": "1.9.3"
   },
   "peerDependencies": {
     "@openfeature/server-sdk": ">=1.16.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -786,7 +786,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bucketco/node-sdk@npm:1.9.2, @bucketco/node-sdk@workspace:packages/node-sdk":
+"@bucketco/node-sdk@npm:1.9.3, @bucketco/node-sdk@workspace:packages/node-sdk":
   version: 0.0.0-use.local
   resolution: "@bucketco/node-sdk@workspace:packages/node-sdk"
   dependencies:
@@ -836,7 +836,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:~7.24.7"
     "@bucketco/eslint-config": "npm:~0.0.2"
-    "@bucketco/node-sdk": "npm:1.9.2"
+    "@bucketco/node-sdk": "npm:1.9.3"
     "@bucketco/tsconfig": "npm:~0.0.2"
     "@openfeature/core": "npm:^1.5.0"
     "@openfeature/server-sdk": "npm:>=1.16.1"


### PR DESCRIPTION
The `getFeatures` endpoint is mostly used to serialize flags for the frontend. When that happens, "checks" will be sent for all features.