### PR TITLE
fix: version check can cause failures

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -35,7 +35,13 @@ type Options = {
 
 async function main() {
   // Start a version check in the background
-  const cliVersionCheckPromise = checkLatestVersion();
+  // unhandled promise rejection can happen even without the `await`
+  // so we need a `catch` here.
+  const cliVersionCheckPromise = checkLatestVersion().catch(() => ({
+    latestVersion: "unknown",
+    currentVersion: "unknown",
+    isNewerAvailable: false,
+  }));
 
   // Must load tokens and config before anything else
   await authStore.initialize();

--- a/packages/cli/utils/version.ts
+++ b/packages/cli/utils/version.ts
@@ -25,41 +25,36 @@ export async function current() {
 }
 
 async function getLatestVersionFromNpm(packageName: string): Promise<string> {
-  // await new Promise((resolve) => setTimeout(resolve, 1000));
-  throw new Error(`Failed to fetch latest version from npm: ${packageName}`);
-  // try {
-  //   const response = await fetch(`https://registry.npmjs.org/${packageName}`, {
-  //     signal: AbortSignal.timeout(5000),
-  //   });
+  try {
+    const response = await fetch(`https://registry.npmjs.org/${packageName}`, {
+      signal: AbortSignal.timeout(5000),
+    });
 
-  //   if (!response.ok) {
-  //     throw new Error(
-  //       `Failed to fetch package info: ${response.status} ${response.statusText}`,
-  //     );
-  //   }
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch package info: ${response.status} ${response.statusText}`,
+      );
+    }
 
-  //   const data: {
-  //     "dist-tags": {
-  //       latest: string;
-  //     };
-  //   } = await response.json();
+    const data: {
+      "dist-tags": {
+        latest: string;
+      };
+    } = await response.json();
 
-  //   return data["dist-tags"].latest;
-  // } catch (error) {
-  //   throw new Error(
-  //     `Failed to fetch latest version from npm: ${error instanceof Error ? error.message : "Unknown error"}`,
-  //   );
-  // }
+    return data["dist-tags"].latest;
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch latest version from npm: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
 }
 
 export async function checkLatest() {
   const { version: currentVersion, name: packageName } = await current();
 
-  const latestVersion = await getLatestVersionFromNpm(packageName).catch(
-    () => null,
-  );
-  const isNewerAvailable =
-    latestVersion !== null && gt(latestVersion, currentVersion);
+  const latestVersion = await getLatestVersionFromNpm(packageName);
+  const isNewerAvailable = gt(latestVersion, currentVersion);
   return {
     currentVersion,
     latestVersion,


### PR DESCRIPTION
If the version check is blocked for some reason, the process can fail. Apparently promise rejections can happen without `await` calls.