### PR TITLE
fix: new function `quoteKey` for object keys with special characters

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reflag/cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "packageManager": "yarn@4.1.1",
   "description": "CLI for Reflag service",
   "main": "./dist/index.js",
@@ -31,8 +31,9 @@
   "scripts": {
     "build": "tsc && shx chmod +x dist/index.js",
     "reflag": "yarn build && ./dist/index.js",
-    "test": "vitest -c vite.config.js",
-    "test:ci": "vitest run -c vite.config.js --reporter=default --reporter=junit --outputFile=junit.xml",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ci": "yarn test --reporter=default --reporter=junit --outputFile=junit.xml",
     "coverage": "vitest run --coverage",
     "lint": "eslint .",
     "lint:ci": "eslint --output-file eslint-report.json --format json .",

--- a/packages/cli/test/json.test.ts
+++ b/packages/cli/test/json.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   JSONToType,
   mergeTypeASTs,
+  quoteKey,
   stringifyTypeAST,
   toTypeAST,
   TypeAST,
@@ -300,6 +301,37 @@ describe("JSON utilities", () => {
       expect(stringifyTypeAST({ kind: "object", properties: [] })).toBe("{}");
     });
 
+    it("should quote object keys with special characters", () => {
+      const ast: TypeAST = {
+        kind: "object",
+        properties: [
+          {
+            key: "my-key",
+            type: { kind: "primitive", type: "string" },
+            optional: false,
+          },
+          {
+            key: "my key",
+            type: { kind: "primitive", type: "string" },
+            optional: false,
+          },
+          {
+            key: "my.key",
+            type: { kind: "primitive", type: "string" },
+            optional: false,
+          },
+          {
+            key: "123key",
+            type: { kind: "primitive", type: "string" },
+            optional: false,
+          },
+        ],
+      };
+
+      const expected = `{\n  "my-key": string,\n  "my key": string,\n  "my.key": string,\n  "123key": string\n}`;
+      expect(stringifyTypeAST(ast)).toBe(expected);
+    });
+
     it("should stringify union types", () => {
       const ast: TypeAST = {
         kind: "union",
@@ -420,6 +452,16 @@ describe("JSON utilities", () => {
           },
         ]),
       ).toBe(expected);
+    });
+  });
+
+  describe("quoteKey", () => {
+    it("should quote keys with special characters", () => {
+      expect(quoteKey("my-key")).toBe('"my-key"');
+      expect(quoteKey("my key")).toBe('"my key"');
+      expect(quoteKey("my.key")).toBe('"my.key"');
+      expect(quoteKey("123key")).toBe('"123key"');
+      expect(quoteKey("key")).toBe("key");
     });
   });
 });

--- a/packages/cli/utils/gen.ts
+++ b/packages/cli/utils/gen.ts
@@ -4,7 +4,7 @@ import { dirname, isAbsolute, join } from "node:path";
 
 import { Flag, RemoteConfig } from "../services/flags.js";
 
-import { JSONToType } from "./json.js";
+import { JSONToType, quoteKey } from "./json.js";
 
 export type GenFormat = "react" | "node";
 
@@ -118,7 +118,7 @@ ${flags
   .map(({ key }) => {
     const config = configDefs.get(key);
     return indentLines(
-      `"${key}": ${config?.definition ? `{ config: { payload: ${config.name} } }` : "boolean"};`,
+      `${quoteKey(key)}: ${config?.definition ? `{ config: { payload: ${config.name} } }` : "boolean"};`,
       4,
     );
   })

--- a/packages/cli/utils/json.ts
+++ b/packages/cli/utils/json.ts
@@ -179,13 +179,12 @@ export function stringifyTypeAST(ast: TypeAST, nestLevel = 0): string {
       if (ast.properties.length === 0) return "{}";
 
       return `{\n${ast.properties
-        .map(
-          ({ key, optional, type }) =>
-            `${nextIndent}${key}${optional ? "?" : ""}: ${stringifyTypeAST(
-              type,
-              nestLevel + 1,
-            )}`,
-        )
+        .map(({ key, optional, type }) => {
+          return `${nextIndent}${quoteKey(key)}${optional ? "?" : ""}: ${stringifyTypeAST(
+            type,
+            nestLevel + 1,
+          )}`;
+        })
         .join(",\n")}\n${indent}}`;
 
     case "union":
@@ -196,6 +195,10 @@ export function stringifyTypeAST(ast: TypeAST, nestLevel = 0): string {
         .map((type) => stringifyTypeAST(type, nestLevel))
         .join(" | ");
   }
+}
+
+export function quoteKey(key: string): string {
+  return /[^a-zA-Z0-9_]/.test(key) || /^[0-9]/.test(key) ? `"${key}"` : key;
 }
 
 // Convert JSON array to TypeScript type


### PR DESCRIPTION
- Introduced new utility function `quoteKey` to handle object keys with special characters in JSON utilities.
- Enhanced `stringifyTypeAST` to utilize `quoteKey` for key quoting, ensuring proper formatting in output.
- Added unit tests for `quoteKey` and updated existing tests to cover new functionality.
- Bumped the CLI version in package.json from 1.0.2 to 1.0.3.
- Modified test scripts for improved functionality:
  - Changed "test" to run vitest directly.
  - Added "test:watch" for continuous testing.
  - Updated "test:ci" to streamline CI testing with reporters.