### PR TITLE
fix(browser-sdk): Handle denied browser storage access

### DIFF
--- a/.changeset/safe-storage-security-error.md
+++ b/.changeset/safe-storage-security-error.md
@@ -1,0 +1,8 @@
+---
+"@reflag/browser-sdk": patch
+"@reflag/openfeature-browser-provider": patch
+"@reflag/react-sdk": patch
+"@reflag/vue-sdk": patch
+---
+
+Handle SecurityError when browser storage access is denied.

--- a/packages/browser-sdk/src/security-error.ts
+++ b/packages/browser-sdk/src/security-error.ts
@@ -1,0 +1,14 @@
+/**
+ * Test if the error is a security error returned by the browser when cookies or local storage are blocked.
+ * Adapted from the Argos CI project.
+ */
+export function checkIsSecurityError(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    // Safari
+    (error.name === "SecurityError" ||
+      // Firefox
+      error.name === "NS_ERROR_FAILURE" ||
+      error.name === "NS_ERROR_ABORT")
+  );
+}

--- a/packages/browser-sdk/src/storage.ts
+++ b/packages/browser-sdk/src/storage.ts
@@ -1,4 +1,5 @@
 import { IS_SERVER } from "./config";
+import { checkIsSecurityError } from "./security-error";
 
 export type StorageAdapter = {
   getItem(key: string): Promise<string | null>;
@@ -14,23 +15,81 @@ export function createNoopStorageAdapter(): StorageAdapter {
   };
 }
 
-export function getLocalStorageAdapter(): StorageAdapter {
-  if (
-    typeof localStorage === "undefined" ||
-    !("setItem" in localStorage) ||
-    !("removeItem" in localStorage)
-  ) {
-    throw new Error(
-      "localStorage is not available. Provide a custom storage adapter.",
-    );
+/**
+ * Get an item from local storage safely.
+ */
+export function getItem(key: string): string | null {
+  try {
+    if (typeof localStorage !== "undefined" && localStorage) {
+      return localStorage.getItem(key);
+    }
+    return null;
+  } catch (error) {
+    if (checkIsSecurityError(error)) {
+      return null;
+    }
+    throw error;
   }
-  return {
-    getItem: async (key) => localStorage.getItem(key),
-    setItem: async (key, value) => {
+}
+
+/**
+ * Set an item in local storage safely.
+ */
+export function setItem(key: string, value: string): boolean {
+  try {
+    if (typeof localStorage !== "undefined" && localStorage) {
       localStorage.setItem(key, value);
+      return true;
+    }
+    return false;
+  } catch (error) {
+    if (checkIsSecurityError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Remove an item from local storage safely.
+ */
+export function removeItem(key: string): void {
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.removeItem(key);
+    }
+  } catch (error) {
+    if (checkIsSecurityError(error)) {
+      return;
+    }
+    throw error;
+  }
+}
+
+export function getLocalStorageAdapter(): StorageAdapter {
+  try {
+    if (
+      typeof localStorage === "undefined" ||
+      !("setItem" in localStorage) ||
+      !("removeItem" in localStorage)
+    ) {
+      throw new Error(
+        "localStorage is not available. Provide a custom storage adapter.",
+      );
+    }
+  } catch (error) {
+    if (!checkIsSecurityError(error)) {
+      throw error;
+    }
+  }
+
+  return {
+    getItem: async (key) => getItem(key),
+    setItem: async (key, value) => {
+      setItem(key, value);
     },
     removeItem: async (key) => {
-      localStorage.removeItem(key);
+      removeItem(key);
     },
   };
 }

--- a/packages/browser-sdk/test/storage.test.ts
+++ b/packages/browser-sdk/test/storage.test.ts
@@ -5,9 +5,36 @@ async function loadStorageModule() {
   return import("../src/storage");
 }
 
+const localStorageDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "localStorage",
+);
+
+function restoreLocalStorageDescriptor() {
+  const descriptor = localStorageDescriptor;
+  if (descriptor) {
+    Object.defineProperty(globalThis, "localStorage", descriptor);
+  } else {
+    delete (globalThis as Record<string, unknown>).localStorage;
+  }
+}
+
+function defineThrowingLocalStorage(errorName = "SecurityError") {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    get() {
+      const error = new Error("Access is denied for this document.");
+      error.name = errorName;
+      throw error;
+    },
+  });
+}
+
 describe("storage adapters", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    restoreLocalStorageDescriptor();
+    localStorage.clear();
   });
 
   it("noop adapter ignores writes", async () => {
@@ -29,6 +56,20 @@ describe("storage adapters", () => {
       "localStorage is not available. Provide a custom storage adapter.",
     );
   });
+
+  it.each(["SecurityError", "NS_ERROR_FAILURE", "NS_ERROR_ABORT"])(
+    "localStorage adapter ignores %s when storage access is denied",
+    async (errorName) => {
+      const { getLocalStorageAdapter } = await loadStorageModule();
+      defineThrowingLocalStorage(errorName);
+
+      const adapter = getLocalStorageAdapter();
+
+      expect(await adapter.getItem("key")).toBeNull();
+      await expect(adapter.setItem("key", "value")).resolves.toBeUndefined();
+      await expect(adapter.removeItem?.("key")).resolves.toBeUndefined();
+    },
+  );
 
   it("default adapter falls back to noop on server runtimes", async () => {
     vi.resetModules();


### PR DESCRIPTION
## Summary
- Wrap browser storage access so SecurityError from denied localStorage access is ignored
- Return null/no-op when localStorage access is blocked instead of falling back to another storage backend
- Add tests for denied storage access across Safari/Firefox error names

## Tests
- yarn workspace @reflag/browser-sdk vitest run test/storage.test.ts
- cd packages/browser-sdk && PATH=../../node_modules/.bin:./node_modules/.bin:$PATH yarn build

Note: `yarn workspace @reflag/browser-sdk lint` could not run in this environment because `oxlint` was not installed on PATH.