### PR TITLE
fix: preserve updateUser context and flush identity updates

### DIFF
--- a/.changeset/thin-cups-matter.md
+++ b/.changeset/thin-cups-matter.md
@@ -1,0 +1,5 @@
+---
+"@reflag/react-sdk": patch
+---
+
+Prevent provider re-renders with unchanged context props from resetting user or company attributes applied via `useUpdateUser` and `useUpdateCompany`.

--- a/.changeset/tough-flies-push.md
+++ b/.changeset/tough-flies-push.md
@@ -1,0 +1,5 @@
+---
+"@reflag/browser-sdk": patch
+---
+
+Start flushing queued user and company updates immediately when `updateUser` or `updateCompany` changes identity context.

--- a/packages/browser-sdk/src/bulkQueue.ts
+++ b/packages/browser-sdk/src/bulkQueue.ts
@@ -92,10 +92,13 @@ export class BulkQueue {
     this.schedule(this.flushDelayMs);
   }
 
-  async flush() {
+  async flush(): Promise<void> {
     if (this.inFlightPromise) {
       await this.inFlightPromise;
-      return;
+      if (this.queue.length === 0) {
+        return;
+      }
+      return this.flush();
     }
 
     if (this.queue.length === 0) {

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -908,16 +908,24 @@ export class ReflagClient {
 
     this.context = newContext;
 
+    let shouldFlushIdentityUpdate = false;
+
     if (companyChanged) {
       void this.company();
+      shouldFlushIdentityUpdate = true;
     }
 
     if (userChanged) {
       void this.user();
+      shouldFlushIdentityUpdate = true;
       // Update the automatic feedback user if the user ID has changed
       if (userIdChanged) {
         void this.updateAutoFeedbackUser(String(newContext.user!.id));
       }
+    }
+
+    if (shouldFlushIdentityUpdate) {
+      void this.bulkQueue?.flush();
     }
 
     const shouldTrackLoading = this.state === "initialized";

--- a/packages/browser-sdk/test/bulkQueue.test.ts
+++ b/packages/browser-sdk/test/bulkQueue.test.ts
@@ -271,7 +271,7 @@ describe("BulkQueue", () => {
     resolveSend?.(new Response("", { status: 200 }));
   });
 
-  it("requires a second flush to send pending events after an in-flight batch", async () => {
+  it("flush waits for an in-flight batch and sends pending events", async () => {
     let resolveFirstSend: ((res: Response) => void) | undefined;
     const firstSend = new Promise<Response>((resolve) => {
       resolveFirstSend = resolve;
@@ -306,10 +306,6 @@ describe("BulkQueue", () => {
     await flushWhileInFlight;
 
     expect(waitedForInFlight).toBe(true);
-    expect(sendBulk).toHaveBeenCalledTimes(1);
-    expect(await queue.size()).toBe(2);
-
-    await queue.flush();
     expect(sendBulk).toHaveBeenCalledTimes(2);
     expect(sendBulk).toHaveBeenNthCalledWith(2, [trackEvent, lateTrackEvent]);
     expect(await queue.size()).toBe(0);

--- a/packages/browser-sdk/test/client.test.ts
+++ b/packages/browser-sdk/test/client.test.ts
@@ -1,9 +1,11 @@
+import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ReflagClient } from "../src/client";
 import { FlagsClient } from "../src/flag/flags";
 import { HttpClient } from "../src/httpClient";
 import { flagsResult } from "./mocks/handlers";
+import { server } from "./mocks/server";
 
 describe("ReflagClient", () => {
   let client: ReflagClient;
@@ -71,6 +73,84 @@ describe("ReflagClient", () => {
         "No company Id provided in context, company will be ignored",
       );
     });
+
+    it("starts flushing the user update before refetching flags without waiting for it", async () => {
+      const requests: string[] = [];
+      let bulkResolved = false;
+      let resolveBulk: ((response: HttpResponse) => void) | undefined;
+      const bulkResponse = new Promise<HttpResponse>((resolve) => {
+        resolveBulk = (response) => {
+          bulkResolved = true;
+          resolve(response);
+        };
+      });
+
+      server.use(
+        http.post("https://front.reflag.com/bulk", async ({ request }) => {
+          requests.push("bulk");
+          const data = await request.json();
+          const userEvent = Array.isArray(data)
+            ? data.find((event) => event?.type === "user")
+            : undefined;
+          expect(userEvent?.attributes?.siteCentricOptIn).toBe("true");
+
+          return bulkResponse;
+        }),
+        http.get(
+          "https://front.reflag.com/features/evaluated",
+          ({ request }) => {
+            requests.push("flags");
+            const url = new URL(request.url);
+            expect(url.searchParams.get("context.user.siteCentricOptIn")).toBe(
+              "true",
+            );
+
+            return HttpResponse.json({
+              success: true,
+              features: {
+                SITE_CENTRIC: {
+                  key: "SITE_CENTRIC",
+                  isEnabled: true,
+                  targetingVersion: 1,
+                },
+              },
+            });
+          },
+        ),
+      );
+
+      client = new ReflagClient({
+        publishableKey: "test-key-user-update-before-flags",
+        user: { id: "user1" },
+        bootstrappedFlags: {
+          SITE_CENTRIC: {
+            key: "SITE_CENTRIC",
+            isEnabled: false,
+            targetingVersion: 1,
+          },
+        },
+        trackingQueue: {
+          flushDelayMs: 2_000,
+        },
+      });
+      await client.initialize();
+
+      const updatePromise = client.updateUser({ siteCentricOptIn: "true" });
+
+      try {
+        await vi.waitFor(() => expect(requests).toEqual(["bulk", "flags"]));
+
+        let updateResolved = false;
+        void updatePromise.then(() => {
+          updateResolved = true;
+        });
+        await vi.waitFor(() => expect(updateResolved).toBe(true));
+        expect(bulkResolved).toBe(false);
+      } finally {
+        resolveBulk?.(HttpResponse.json({ success: true }));
+        await updatePromise;
+      }
+    });
   });
 
   describe("updateCompany", () => {
@@ -99,6 +179,50 @@ describe("ReflagClient", () => {
         }),
       );
       expect(flagClientSetContext).toHaveBeenCalledWith(client["context"]);
+    });
+
+    it("starts flushing the company update before refetching flags", async () => {
+      const requests: string[] = [];
+      let resolveCompanyPlan: ((plan: unknown) => void) | undefined;
+      const companyPlan = new Promise<unknown>((resolve) => {
+        resolveCompanyPlan = resolve;
+      });
+
+      server.use(
+        http.post("https://front.reflag.com/bulk", async ({ request }) => {
+          requests.push("bulk");
+          const data = await request.json();
+          const companyEvent = Array.isArray(data)
+            ? data.find((event) => event?.type === "company")
+            : undefined;
+          resolveCompanyPlan?.(companyEvent?.attributes?.plan);
+
+          return HttpResponse.json({ success: true });
+        }),
+        http.get("https://front.reflag.com/features/evaluated", () => {
+          requests.push("flags");
+          return HttpResponse.json({
+            success: true,
+            features: {},
+          });
+        }),
+      );
+
+      client = new ReflagClient({
+        publishableKey: "test-key-company-update-before-flags",
+        user: { id: "user1" },
+        company: { id: "company1" },
+        bootstrappedFlags: {},
+        trackingQueue: {
+          flushDelayMs: 2_000,
+        },
+      });
+      await client.initialize();
+
+      await client.updateCompany({ plan: "enterprise" });
+
+      expect(requests).toEqual(["bulk", "flags"]);
+      await expect(companyPlan).resolves.toBe("enterprise");
     });
   });
 

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -193,11 +193,6 @@ export type ReflagInitOptionsBase = Omit<
  */
 const reflagClients = new Map<string, ReflagClient>();
 
-/**
- * Returns the ReflagClient for a given publishable key.
- * Only creates a new ReflagClient is not already created or if it hook is run on the server.
- * @internal
- */
 function contextPartEqual(
   a?: Record<string, string | number | undefined>,
   b?: Record<string, string | number | undefined>,
@@ -222,6 +217,11 @@ function contextEqual(a: ReflagContext, b: ReflagContext) {
   );
 }
 
+/**
+ * Returns the ReflagClient for a given publishable key.
+ * Only creates a new ReflagClient if it is not already created or if the hook is run on the server.
+ * @internal
+ */
 function useReflagClient(initOptions: InitOptions & { debug?: boolean }) {
   const {
     debug = false,

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -7,6 +7,7 @@ import React, {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -197,6 +198,30 @@ const reflagClients = new Map<string, ReflagClient>();
  * Only creates a new ReflagClient is not already created or if it hook is run on the server.
  * @internal
  */
+function contextPartEqual(
+  a?: Record<string, string | number | undefined>,
+  b?: Record<string, string | number | undefined>,
+) {
+  if (a === b) return true;
+  if (!a || !b) return !a && !b;
+
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+
+  return aKeys.every(
+    (key) => Object.prototype.hasOwnProperty.call(b, key) && a[key] === b[key],
+  );
+}
+
+function contextEqual(a: ReflagContext, b: ReflagContext) {
+  return (
+    contextPartEqual(a.user, b.user) &&
+    contextPartEqual(a.company, b.company) &&
+    contextPartEqual(a.other, b.other)
+  );
+}
+
 function useReflagClient(initOptions: InitOptions & { debug?: boolean }) {
   const {
     debug = false,
@@ -322,6 +347,9 @@ export function ReflagProvider({
     () => ({ user, company, other: otherContext, ...context }),
     [user, company, otherContext, context],
   );
+  const lastAppliedProviderContext = useRef<ReflagContext | undefined>(
+    undefined,
+  );
   const client = useReflagClient({
     ...config,
     ...resolvedContext,
@@ -337,8 +365,16 @@ export function ReflagProvider({
     });
   }, [client]);
 
-  // Update the context if it changes
+  // Update the context if provider props semantically change. Keep this
+  // independent from the client's current context so imperative updates via
+  // useUpdateUser/useUpdateCompany are not reset by unrelated provider re-renders.
   useEffect(() => {
+    const previousContext = lastAppliedProviderContext.current;
+    if (previousContext && contextEqual(previousContext, resolvedContext)) {
+      return;
+    }
+
+    lastAppliedProviderContext.current = resolvedContext;
     void client.setContext(resolvedContext);
   }, [client, resolvedContext]);
 

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -496,6 +496,74 @@ describe("useUpdateUser", () => {
     });
 
     unmount();
+    updateUser.mockRestore();
+  });
+
+  test("preserves user updates across provider rerenders with unchanged context props", async () => {
+    const publishableKey = `KEY-${keyIndex++}`;
+    const seenOptInValues: (string | null)[] = [];
+    let updateUser!: ReturnType<typeof useUpdateUser>;
+    let client!: ReflagClient;
+
+    server.use(
+      http.get(/\/features\/evaluated$/, ({ request }) => {
+        const siteCentricOptIn = new URL(request.url).searchParams.get(
+          "context.user.siteCentricOptIn",
+        );
+        seenOptInValues.push(siteCentricOptIn);
+
+        return HttpResponse.json({
+          success: true,
+          features: {
+            SITE_CENTRIC: {
+              key: "SITE_CENTRIC",
+              isEnabled: siteCentricOptIn === "true",
+              targetingVersion: 1,
+            },
+          },
+        });
+      }),
+    );
+
+    function CaptureClient() {
+      updateUser = useUpdateUser();
+      client = useClient();
+      return null;
+    }
+
+    function ProviderShell() {
+      return (
+        <ReflagProvider
+          context={{ user: { id: "456", name: "test" }, company, other }}
+          enableLiveFlagUpdates={false}
+          enableTracking={false}
+          feedback={{ enableAutoFeedback: false }}
+          initialLoading={false}
+          publishableKey={publishableKey}
+        >
+          <CaptureClient />
+        </ReflagProvider>
+      );
+    }
+
+    const { rerender, unmount } = render(<ProviderShell />);
+
+    await waitFor(() => expect(seenOptInValues).toEqual([null]));
+
+    await act(async () => {
+      await updateUser({ siteCentricOptIn: "true" });
+    });
+    await waitFor(() => expect(seenOptInValues).toEqual([null, "true"]));
+
+    rerender(<ProviderShell />);
+    await act(async () => undefined);
+
+    expect(client.getContext().user).toMatchObject({
+      siteCentricOptIn: "true",
+    });
+    expect(seenOptInValues).toEqual([null, "true"]);
+
+    unmount();
   });
 });
 


### PR DESCRIPTION
## Summary
- Only call `setContext` from `ReflagProvider` when provider context props semantically change
- Preserve attributes added via `useUpdateUser`/`useUpdateCompany` across unrelated provider rerenders
- Start flushing queued user/company bulk updates immediately when identity context changes, without waiting for the flush before refetching flags
- Add regression coverage for `flagOptIn` targeting and immediate identity-update flush behavior

## Testing
- yarn workspace @reflag/browser-sdk test
- yarn workspace @reflag/browser-sdk build
- yarn workspace @reflag/react-sdk test
- yarn workspace @reflag/react-sdk build
- yarn oxlint packages/browser-sdk packages/react-sdk
- yarn oxfmt --check packages/browser-sdk/src/client.ts packages/browser-sdk/src/bulkQueue.ts packages/browser-sdk/test/bulkQueue.test.ts packages/browser-sdk/test/client.test.ts packages/react-sdk/src/index.tsx packages/react-sdk/test/usage.test.tsx .changeset/thin-cups-matter.md .changeset/tough-flies-push.md