### PR TITLE
Document React Native Suspense support

### DIFF
--- a/.changeset/young-pandas-suspend.md
+++ b/.changeset/young-pandas-suspend.md
@@ -1,0 +1,5 @@
+---
+"@reflag/react-native-sdk": patch
+---
+
+Re-export `UseFlagOptions` and document the React Native SDK's inherited Suspense support.

--- a/.changeset/young-pandas-suspend.md
+++ b/.changeset/young-pandas-suspend.md
@@ -2,4 +2,4 @@
 "@reflag/react-native-sdk": patch
 ---
 
-Re-export `UseFlagOptions` and document the React Native SDK's inherited Suspense support.
+Add Suspense support for `useFlag` while flags are loading via provider-level and per-hook `suspense` options. Re-export `UseFlagOptions` and document React Native usage.

--- a/.changeset/young-pandas-suspend.md
+++ b/.changeset/young-pandas-suspend.md
@@ -2,4 +2,4 @@
 "@reflag/react-native-sdk": patch
 ---
 
-Add Suspense support for `useFlag` while flags are loading via provider-level and per-hook `suspense` options. Re-export `UseFlagOptions` and document React Native usage.
+Add Suspense support for `useFlag` while flags are loading via provider-level and per-hook `suspense` options.

--- a/packages/react-native-sdk/README.md
+++ b/packages/react-native-sdk/README.md
@@ -48,24 +48,6 @@ function StartHuddleButton() {
 
 See the [React SDK README](../react-sdk/README.md) for more details.
 
-### Suspense loading
-
-React Native uses the same Suspense support as the React SDK. Enable it for the provider and wrap components that call `useFlag` in a Suspense boundary:
-
-```tsx
-import { Suspense } from "react";
-import { ActivityIndicator } from "react-native";
-import { ReflagProvider } from "@reflag/react-native-sdk";
-
-<ReflagProvider publishableKey="{YOUR_PUBLISHABLE_KEY}" suspense>
-  <Suspense fallback={<ActivityIndicator />}>
-    <App />
-  </Suspense>
-</ReflagProvider>;
-```
-
-You can also override the behavior for one call with `useFlag("huddle", { suspense: true })`.
-
 ## React Native differences
 
 - The Reflag toolbar is web-only and is not available in React Native.
@@ -121,6 +103,26 @@ export function App() {
   );
 }
 ```
+
+
+## Suspense loading
+
+Enable `<Suspense>` support by setting the `suspense` prop on the provider and wrap components that call `useFlag` in a Suspense boundary:
+
+```tsx
+import { Suspense } from "react";
+import { ActivityIndicator } from "react-native";
+import { ReflagProvider } from "@reflag/react-native-sdk";
+
+<ReflagProvider publishableKey="{YOUR_PUBLISHABLE_KEY}" suspense>
+  <Suspense fallback={<ActivityIndicator />}>
+    <App />
+  </Suspense>
+</ReflagProvider>;
+```
+
+You can also override the behavior for one call with `useFlag("huddle", { suspense: true })`.
+
 
 ## Bootstrapping
 

--- a/packages/react-native-sdk/README.md
+++ b/packages/react-native-sdk/README.md
@@ -48,6 +48,24 @@ function StartHuddleButton() {
 
 See the [React SDK README](../react-sdk/README.md) for more details.
 
+### Suspense loading
+
+React Native uses the same Suspense support as the React SDK. Enable it for the provider and wrap components that call `useFlag` in a Suspense boundary:
+
+```tsx
+import { Suspense } from "react";
+import { ActivityIndicator } from "react-native";
+import { ReflagProvider } from "@reflag/react-native-sdk";
+
+<ReflagProvider publishableKey="{YOUR_PUBLISHABLE_KEY}" suspense>
+  <Suspense fallback={<ActivityIndicator />}>
+    <App />
+  </Suspense>
+</ReflagProvider>;
+```
+
+You can also override the behavior for one call with `useFlag("huddle", { suspense: true })`.
+
 ## React Native differences
 
 - The Reflag toolbar is web-only and is not available in React Native.

--- a/packages/react-native-sdk/README.md
+++ b/packages/react-native-sdk/README.md
@@ -104,7 +104,6 @@ export function App() {
 }
 ```
 
-
 ## Suspense loading
 
 Enable `<Suspense>` support by setting the `suspense` prop on the provider and wrap components that call `useFlag` in a Suspense boundary:
@@ -122,7 +121,6 @@ import { ReflagProvider } from "@reflag/react-native-sdk";
 ```
 
 You can also override the behavior for one call with `useFlag("huddle", { suspense: true })`.
-
 
 ## Bootstrapping
 

--- a/packages/react-native-sdk/src/index.tsx
+++ b/packages/react-native-sdk/src/index.tsx
@@ -22,6 +22,7 @@ import type {
   StorageAdapter,
   TrackEvent,
   TypedFlags,
+  UseFlagOptions,
   UserContext,
 } from "@reflag/react-sdk";
 import {
@@ -84,6 +85,7 @@ export type {
   StorageAdapter,
   TrackEvent,
   TypedFlags,
+  UseFlagOptions,
   UserContext,
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #687 for `@reflag/react-native-sdk`.

The React Native package already inherits provider-level and per-hook Suspense behavior by re-exporting the React SDK implementation. This PR completes the React Native package surface by:

- re-exporting the `UseFlagOptions` type
- documenting provider-level Suspense usage with React Native components
- documenting the per-hook `suspense` override
- adding a React Native SDK patch changeset

## Validation

- `oxlint packages/react-native-sdk/src/index.tsx`
- `tsc --project packages/react-native-sdk/tsconfig.build.json`
- Changesets schedules `@reflag/react-native-sdk` `0.2.6`
