### PR TITLE
Fix opt-in flag typing and bootstrap loading state

### DIFF
--- a/.changeset/fuzzy-dodos-opt-in.md
+++ b/.changeset/fuzzy-dodos-opt-in.md
@@ -4,4 +4,4 @@
 "@reflag/vue-sdk": patch
 ---
 
-Fix React and Vue opt-in flag keys to respect generated flag types, and return reliable loading state from `useOptInFlags()` while bootstrapped clients fetch missing opt-in metadata. React's hook also supports Suspense.
+Fix React and Vue opt-in flag keys to respect generated flag types, and return reliable loading state from `useOptInFlags()` while bootstrapped clients fetch opt-in metadata. React's hook also supports Suspense.

--- a/.changeset/fuzzy-dodos-opt-in.md
+++ b/.changeset/fuzzy-dodos-opt-in.md
@@ -3,4 +3,4 @@
 "@reflag/react-sdk": patch
 ---
 
-Fix React opt-in flag keys to respect generated flag types, and expose reliable loading and Suspense states while bootstrapped clients fetch missing opt-in metadata.
+Fix React opt-in flag keys to respect generated flag types, and return reliable loading and Suspense states from `useOptInFlags()` while bootstrapped clients fetch missing opt-in metadata.

--- a/.changeset/fuzzy-dodos-opt-in.md
+++ b/.changeset/fuzzy-dodos-opt-in.md
@@ -1,6 +1,7 @@
 ---
 "@reflag/browser-sdk": patch
 "@reflag/react-sdk": patch
+"@reflag/vue-sdk": patch
 ---
 
-Fix React opt-in flag keys to respect generated flag types, and return reliable loading and Suspense states from `useOptInFlags()` while bootstrapped clients fetch missing opt-in metadata.
+Fix React and Vue opt-in flag keys to respect generated flag types, and return reliable loading state from `useOptInFlags()` while bootstrapped clients fetch missing opt-in metadata. React's hook also supports Suspense.

--- a/.changeset/fuzzy-dodos-opt-in.md
+++ b/.changeset/fuzzy-dodos-opt-in.md
@@ -1,0 +1,6 @@
+---
+"@reflag/browser-sdk": patch
+"@reflag/react-sdk": patch
+---
+
+Fix React opt-in flag keys to respect generated flag types, and expose reliable loading and Suspense states while bootstrapped clients fetch missing opt-in metadata.

--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -212,6 +212,7 @@ If a flag has end-user opt-in enabled in Reflag, you can list the opt-in options
 
 ```ts
 const optInFlags = reflagClient.getOptInFlags();
+const isLoadingOptInFlags = reflagClient.getIsLoadingOptInFlags();
 // [{ key, name, description, isEnabled, userOptedIn, companyOptedIn, isOptedIn }]
 
 await reflagClient.setOptIn("huddle", { optedIn: true });
@@ -231,7 +232,9 @@ User and company opt-ins are managed independently. Setting `optedIn` to `false`
 
 The `description` comes from the dedicated SDK-facing opt-in description configured in Reflag.
 
-When the client was bootstrapped without browser opt-in metadata, the first `getOptInFlags()` call starts one evaluated-flags refresh. The call returns the currently available list synchronously, and `flagsUpdated` is emitted when the refreshed list is available.
+When the client was bootstrapped without browser opt-in metadata, the first `getOptInFlags()` or `getIsLoadingOptInFlags()` call starts one evaluated-flags refresh. The list call returns the currently available list synchronously. `getIsLoadingOptInFlags()` returns `true` until the refresh succeeds or fails, then returns `false`. It returns `false` immediately when the bootstrapped payload already contains complete opt-in metadata. This loading getter is primarily relevant to bootstrapped clients because normal initialization already exposes loading through the client's state.
+
+Listen for `optInFlagsLoadingUpdated` to update UI when this loading state changes. `flagsUpdated` is emitted when a successful refresh updates the list.
 
 ## Remote config
 
@@ -506,10 +509,11 @@ reflagClient.track("huddle", { voiceHuddle: true });
 
 ## Event listeners
 
-Event listeners allow for capturing various events occurring in the `ReflagClient`. This is useful to build integrations with other system or for various debugging purposes. There are 5 kinds of events:
+Event listeners allow for capturing various events occurring in the `ReflagClient`. This is useful to build integrations with other system or for various debugging purposes. The available events are:
 
 - `check`: Your code used `isEnabled` or `config` for a flag
 - `flagsUpdated`: Flags were updated. Either because they were loaded as part of initialization or because the user/company updated
+- `optInFlagsLoadingUpdated`: The opt-in flag loading state changed
 - `user`: User information updated (similar to the `identify` call used in tracking terminology)
 - `company`: Company information updated (sometimes to the `group` call used in tracking terminology)
 - `track`: Track event occurred.

--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -232,7 +232,7 @@ User and company opt-ins are managed independently. Setting `optedIn` to `false`
 
 The `description` comes from the dedicated SDK-facing opt-in description configured in Reflag.
 
-When the client was bootstrapped without browser opt-in metadata, the first `getOptInFlags()` or `getIsLoadingOptInFlags()` call starts one evaluated-flags refresh. The list call returns the currently available list synchronously. `getIsLoadingOptInFlags()` returns `true` until the refresh succeeds or fails, then returns `false`. It returns `false` immediately when the bootstrapped payload already contains complete opt-in metadata. This loading getter is primarily relevant to bootstrapped clients because normal initialization already exposes loading through the client's state.
+For a bootstrapped client, the first `getOptInFlags()` or `getIsLoadingOptInFlags()` call starts one flags refresh. The list call returns the currently available list synchronously, and the loading getter returns `true` until the refresh succeeds or fails. Normal initialization already exposes loading through the client's state.
 
 Listen for `optInFlagsLoadingUpdated` to update UI when this loading state changes. `flagsUpdated` is emitted when a successful refresh updates the list.
 
@@ -333,7 +333,7 @@ The `bootstrappedState` object contains:
 
 If you want live flag updates to continue working after bootstrapping, use a recent `@reflag/node-sdk` so `getFlagsForBootstrap()` includes `flagStateVersion`.
 
-The bootstrap payload is available synchronously for the initial render. If the application requests opt-in flags and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. Bootstrapped applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use.
+If a bootstrapped application requests opt-in flags, the browser SDK performs one flags refresh. Applications that do not request opt-in data do not make this request.
 
 If you previously used `bootstrappedFlags`, migrate like this:
 

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -486,7 +486,6 @@ function shouldShowToolbar(opts: InitOptions) {
 export class ReflagClient {
   private state: State = "idle";
   private contextUpdateLoading = false;
-  private optInFlagsRequested = false;
   private readonly publishableKey: string;
   private context: ReflagContext;
   private config: Config;
@@ -662,6 +661,9 @@ export class ReflagClient {
     this.flagsClient.onUpdated(() => {
       this.hooks.trigger("flagsUpdated", this.flagsClient.getFlags());
     });
+    this.flagsClient.onOptInFlagsLoadingUpdated((isLoading) => {
+      this.hooks.trigger("optInFlagsLoadingUpdated", isLoading);
+    });
   }
 
   /**
@@ -687,9 +689,6 @@ export class ReflagClient {
     }
 
     await this.flagsClient.initialize();
-    if (this.optInFlagsRequested) {
-      void this.refreshOptInMetadataIfNeeded();
-    }
 
     // Open SSE after the initial flag load. The pubsub server replays the
     // latest flag-update message, including `flagStateVersion`, so
@@ -1003,7 +1002,10 @@ export class ReflagClient {
         incomingFlagStateVersion < latestKnownFlagStateVersion);
 
     this.context = newContext;
-    this.flagsClient.setContextWithoutFetch(newContext);
+    this.flagsClient.setContextWithoutFetch(
+      newContext,
+      !shouldIgnoreIncomingFlags,
+    );
 
     if (!shouldIgnoreIncomingFlags) {
       this.flagsClient.resetOptInMetadataRefresh();
@@ -1012,9 +1014,7 @@ export class ReflagClient {
         triggerEvent,
         incomingFlagStateVersion,
       );
-      if (this.optInFlagsRequested) {
-        void this.refreshOptInMetadataIfNeeded();
-      }
+      this.flagsClient.markBootstrappedStateApplied();
     }
 
     if (contextChanged) {
@@ -1225,10 +1225,7 @@ export class ReflagClient {
    * Returns opt-in-enabled flags for the current context.
    */
   getOptInFlags(): OptInFlag[] {
-    this.optInFlagsRequested = true;
-    if (this.state === "initialized") {
-      void this.refreshOptInMetadataIfNeeded();
-    }
+    this.flagsClient.requestOptInFlags();
 
     return Object.values(this.getFlags()).flatMap((flag) => {
       if (flag.optInEnabled !== true || !flag.optIn) return [];
@@ -1243,6 +1240,16 @@ export class ReflagClient {
         isOptedIn: flag.optIn.isOptedIn,
       } satisfies OptInFlag;
     });
+  }
+
+  /**
+   * Returns whether opt-in flags are loading for the current context.
+   *
+   * Calling this method requests opt-in metadata if it is not already available.
+   */
+  getIsLoadingOptInFlags(): boolean {
+    this.flagsClient.requestOptInFlags();
+    return this.flagsClient.getIsLoadingOptInFlags();
   }
 
   /**
@@ -1463,14 +1470,6 @@ export class ReflagClient {
       reflagClient: this,
       position,
     });
-  }
-
-  private async refreshOptInMetadataIfNeeded() {
-    try {
-      await this.flagsClient.refreshOptInMetadataIfNeeded();
-    } catch (error) {
-      this.logger.error("error refreshing opt-in flag metadata", error);
-    }
   }
 
   private finishContextUpdate() {

--- a/packages/browser-sdk/src/client.ts
+++ b/packages/browser-sdk/src/client.ts
@@ -344,13 +344,13 @@ export type InitOptions = ReflagDeprecatedContext & {
 
   /**
    * Pre-fetched evaluated state used for the initial flag state.
-   * If opt-in flags are requested and browser opt-in metadata is missing, the client refreshes it on demand.
+   * The client fetches opt-in metadata on demand when opt-in flags are requested.
    */
   bootstrappedState?: BootstrappedState;
 
   /**
    * Pre-fetched flags used for the initial flag state.
-   * If opt-in flags are requested and browser opt-in metadata is missing, the client refreshes them on demand.
+   * The client fetches opt-in metadata on demand when opt-in flags are requested.
    * @deprecated Use `bootstrappedState` instead.
    */
   bootstrappedFlags?: RawFlags;

--- a/packages/browser-sdk/src/flag/flags.ts
+++ b/packages/browser-sdk/src/flag/flags.ts
@@ -274,6 +274,7 @@ type FlagsClientOptions = Partial<Config> & {
 export class FlagsClient {
   private initialized = false;
   private bootstrapped = false;
+  private initializationComplete = false;
 
   private rateLimiter: RateLimiter;
   private readonly logger: Logger;
@@ -286,7 +287,17 @@ export class FlagsClient {
   private flags: RawFlags = {};
   private fallbackFlags: FallbackFlags = {};
   private contextFetchVersion = 0;
+  private optInFlagsRequested = false;
+  private optInFlagsLoading = false;
+  private optInFlagsLoadingGeneration = 0;
   private optInMetadataRefreshAttemptContextVersion: number | undefined;
+  private optInMetadataRefresh:
+    | {
+        contextVersion: number;
+        id: object;
+        promise: Promise<void>;
+      }
+    | undefined;
   private storage: StorageAdapter;
   private refreshEvents: number[] = [];
   private enqueueBulkEvent?: (event: BulkEvent) => Promise<void>;
@@ -343,28 +354,43 @@ export class FlagsClient {
     }
     this.initialized = true;
 
-    const cachedOverrides = await this.getOverridesCache();
-    if (Object.keys(cachedOverrides).length > 0) {
-      this.flagOverrides = { ...cachedOverrides, ...this.flagOverrides };
-    }
+    let initializationSucceeded = false;
+    try {
+      const cachedOverrides = await this.getOverridesCache();
+      if (Object.keys(cachedOverrides).length > 0) {
+        this.flagOverrides = { ...cachedOverrides, ...this.flagOverrides };
+      }
 
-    if (!this.bootstrapped) {
-      const requestContextVersion = this.contextFetchVersion;
-      this.applyFetchedFlagsResult(
-        await this.maybeFetchFlags(requestContextVersion),
-        true,
-        requestContextVersion,
-      );
-    }
+      if (!this.bootstrapped) {
+        const requestContextVersion = this.contextFetchVersion;
+        this.applyFetchedFlagsResult(
+          await this.maybeFetchFlags(requestContextVersion),
+          true,
+          requestContextVersion,
+        );
+      }
 
-    // Apply overrides and trigger update if flags have changed
-    this.updateFlags();
+      // Apply overrides and trigger update if flags have changed
+      this.updateFlags();
+      initializationSucceeded = true;
+    } finally {
+      this.initializationComplete = true;
+
+      if (this.optInFlagsRequested) {
+        if (initializationSucceeded && this.bootstrapped) {
+          void this.refreshOptInMetadataIfNeeded();
+        } else {
+          this.finishOptInFlagsLoading(this.optInFlagsLoadingGeneration);
+        }
+      }
+    }
   }
 
   /**
    * Stop the client.
    */
   public stop() {
+    this.supersedeOptInFlagsLoading(false);
     this.abortController.abort();
   }
 
@@ -376,35 +402,117 @@ export class FlagsClient {
     return this.fetchedFlags;
   }
 
+  requestOptInFlags() {
+    this.optInFlagsRequested = true;
+
+    if (
+      !this.initializationComplete ||
+      this.fetchedFlagsContextVersion !== this.contextFetchVersion
+    ) {
+      if (!this.bootstrapped || !this.hasOptInMetadataForCurrentContext()) {
+        this.ensureOptInFlagsLoading();
+      }
+      return;
+    }
+
+    if (!this.bootstrapped) {
+      this.finishOptInFlagsLoading(this.optInFlagsLoadingGeneration);
+      return;
+    }
+
+    void this.refreshOptInMetadataIfNeeded();
+  }
+
+  getIsLoadingOptInFlags() {
+    return this.optInFlagsLoading;
+  }
+
+  onOptInFlagsLoadingUpdated(callback: (isLoading: boolean) => void) {
+    const listener = () => callback(this.optInFlagsLoading);
+    this.eventTarget.addEventListener("optInFlagsLoadingUpdated", listener, {
+      signal: this.abortController.signal,
+    });
+  }
+
   resetOptInMetadataRefresh() {
     this.optInMetadataRefreshAttemptContextVersion = undefined;
   }
 
-  async refreshOptInMetadataIfNeeded() {
-    if (!this.bootstrapped) return;
+  markBootstrappedStateApplied() {
+    this.bootstrapped = true;
+    if (!this.optInFlagsRequested) return;
 
-    const fetchedFlags = Object.values(this.fetchedFlags);
-    const hasOptInMetadata =
-      fetchedFlags.length > 0 &&
-      fetchedFlags.every(
-        (flag) =>
-          flag.optInEnabled === false ||
-          (flag.optInEnabled === true && flag.optIn !== undefined),
-      );
-    if (hasOptInMetadata) return;
+    if (this.hasOptInMetadataForCurrentContext()) {
+      this.finishOptInFlagsLoading(this.optInFlagsLoadingGeneration);
+      return;
+    }
+
+    this.ensureOptInFlagsLoading();
+    if (this.initializationComplete) {
+      void this.refreshOptInMetadataIfNeeded();
+    }
+  }
+
+  async refreshOptInMetadataIfNeeded(): Promise<void> {
+    if (!this.bootstrapped || !this.optInFlagsRequested) return;
+
+    if (
+      !this.initializationComplete ||
+      this.fetchedFlagsContextVersion !== this.contextFetchVersion
+    ) {
+      this.ensureOptInFlagsLoading();
+      return;
+    }
+
+    if (this.hasOptInMetadataForCurrentContext()) {
+      this.finishOptInFlagsLoading(this.optInFlagsLoadingGeneration);
+      return;
+    }
 
     const contextVersion = this.contextFetchVersion;
-    if (this.optInMetadataRefreshAttemptContextVersion === contextVersion) {
+    const pendingRefresh = this.optInMetadataRefresh;
+    if (pendingRefresh?.contextVersion === contextVersion) {
+      return pendingRefresh.promise;
+    }
+
+    if (
+      this.config.offline ||
+      this.optInMetadataRefreshAttemptContextVersion === contextVersion
+    ) {
+      this.finishOptInFlagsLoading(this.optInFlagsLoadingGeneration);
       return;
     }
 
     this.optInMetadataRefreshAttemptContextVersion = contextVersion;
-    return this.refreshFlags(this.fetchedFlagStateVersion);
+    this.ensureOptInFlagsLoading();
+    const loadingGeneration = this.optInFlagsLoadingGeneration;
+    const id = {};
+    const promise = (async () => {
+      try {
+        await this.refreshFlags(this.fetchedFlagStateVersion);
+      } catch (error) {
+        this.logger.error("error refreshing opt-in flag metadata", error);
+      } finally {
+        if (this.optInMetadataRefresh?.id === id) {
+          this.optInMetadataRefresh = undefined;
+        }
+        this.finishOptInFlagsLoading(loadingGeneration);
+      }
+    })();
+
+    this.optInMetadataRefresh = { contextVersion, id, promise };
+    return promise;
   }
 
-  setContextWithoutFetch(context: ReflagContext) {
-    if (!deepEqual(this.context, context)) {
+  setContextWithoutFetch(
+    context: ReflagContext,
+    invalidatePendingFetches = false,
+  ) {
+    if (!deepEqual(this.context, context) || invalidatePendingFetches) {
       this.contextFetchVersion += 1;
+      if (this.optInFlagsRequested) {
+        this.startOptInFlagsLoading();
+      }
     }
     this.context = context;
   }
@@ -471,14 +579,25 @@ export class FlagsClient {
   async setContext(context: ReflagContext) {
     this.context = context;
     const requestVersion = ++this.contextFetchVersion;
-    const fetchedFlags = await this.maybeFetchFlags(requestVersion);
+    this.optInMetadataRefreshAttemptContextVersion = requestVersion;
+    const loadingGeneration = this.optInFlagsRequested
+      ? this.startOptInFlagsLoading()
+      : undefined;
 
-    if (requestVersion !== this.contextFetchVersion) {
-      return false;
+    try {
+      const fetchedFlags = await this.maybeFetchFlags(requestVersion);
+
+      if (requestVersion !== this.contextFetchVersion) {
+        return false;
+      }
+
+      this.applyFetchedFlagsResult(fetchedFlags, true, requestVersion);
+      return true;
+    } finally {
+      if (loadingGeneration !== undefined) {
+        this.finishOptInFlagsLoading(loadingGeneration);
+      }
     }
-
-    this.applyFetchedFlagsResult(fetchedFlags, true, requestVersion);
-    return true;
   }
 
   updateFlags(triggerEvent = true) {
@@ -797,6 +916,52 @@ export class FlagsClient {
         {} as RawFlags,
       ),
     };
+  }
+
+  private hasOptInMetadataForCurrentContext() {
+    if (this.fetchedFlagsContextVersion !== this.contextFetchVersion) {
+      return false;
+    }
+
+    const fetchedFlags = Object.values(this.fetchedFlags);
+    return (
+      fetchedFlags.length > 0 &&
+      fetchedFlags.every(
+        (flag) =>
+          flag.optInEnabled === false ||
+          (flag.optInEnabled === true && flag.optIn !== undefined),
+      )
+    );
+  }
+
+  private ensureOptInFlagsLoading() {
+    if (!this.optInFlagsLoading) {
+      this.startOptInFlagsLoading();
+    }
+    return this.optInFlagsLoadingGeneration;
+  }
+
+  private startOptInFlagsLoading() {
+    this.optInFlagsLoadingGeneration += 1;
+    this.setOptInFlagsLoading(true);
+    return this.optInFlagsLoadingGeneration;
+  }
+
+  private finishOptInFlagsLoading(generation: number) {
+    if (generation !== this.optInFlagsLoadingGeneration) return;
+    this.setOptInFlagsLoading(false);
+  }
+
+  private supersedeOptInFlagsLoading(isLoading: boolean) {
+    this.optInFlagsLoadingGeneration += 1;
+    this.setOptInFlagsLoading(isLoading);
+  }
+
+  private setOptInFlagsLoading(isLoading: boolean) {
+    if (this.optInFlagsLoading === isLoading) return;
+
+    this.optInFlagsLoading = isLoading;
+    this.eventTarget.dispatchEvent({ type: "optInFlagsLoadingUpdated" });
   }
 
   private mergeFlags(fetchedFlags: RawFlags, overrides: FlagOverrides) {

--- a/packages/browser-sdk/src/hooksManager.ts
+++ b/packages/browser-sdk/src/hooksManager.ts
@@ -10,6 +10,7 @@ export interface HookArgs {
   stateUpdated: State;
   check: CheckEvent;
   flagsUpdated: RawFlags;
+  optInFlagsLoadingUpdated: boolean;
 
   /**
    * @deprecated Use `flagsUpdated` instead.
@@ -36,6 +37,7 @@ export class HooksManager {
     stateUpdated: ((arg0: State) => void)[];
     check: ((arg0: CheckEvent) => void)[];
     flagsUpdated: ((arg0: RawFlags) => void)[];
+    optInFlagsLoadingUpdated: ((arg0: boolean) => void)[];
     user: ((arg0: UserContext) => void)[];
     company: ((arg0: CompanyContext) => void)[];
     track: ((arg0: TrackEvent) => void)[];
@@ -43,6 +45,7 @@ export class HooksManager {
     stateUpdated: [],
     check: [],
     flagsUpdated: [],
+    optInFlagsLoadingUpdated: [],
     user: [],
     company: [],
     track: [],
@@ -75,6 +78,9 @@ export class HooksManager {
     event: THookType,
     arg: HookArgs[THookType],
   ): void {
-    this.hooks[this._adjustEvent(event)].forEach((hook) => hook(arg as any));
+    const hooks = this.hooks[this._adjustEvent(event)] as Array<
+      (value: HookArgs[THookType]) => void
+    >;
+    hooks.forEach((hook) => hook(arg));
   }
 }

--- a/packages/browser-sdk/test/client.test.ts
+++ b/packages/browser-sdk/test/client.test.ts
@@ -356,6 +356,230 @@ describe("ReflagClient", () => {
       expect(httpClientGet).toHaveBeenCalledTimes(1);
     });
 
+    it("reports opt-in flags as loading during the initial flag fetch", async () => {
+      client = new ReflagClient({
+        publishableKey: "test-key-initial-opt-in-loading",
+        user: { id: "user1" },
+        enableTracking: false,
+      });
+
+      expect(client.getIsLoadingOptInFlags()).toBe(true);
+      await client.initialize();
+      expect(client.getIsLoadingOptInFlags()).toBe(false);
+    });
+
+    it("reports complete bootstrapped opt-in metadata as ready immediately", async () => {
+      client = new ReflagClient({
+        publishableKey: "test-key-complete-bootstrap-opt-in-metadata",
+        user: { id: "user1" },
+        enableTracking: false,
+        bootstrappedFlags: optInFlags(false),
+      });
+
+      expect(client.getIsLoadingOptInFlags()).toBe(false);
+      await client.initialize();
+      expect(client.getIsLoadingOptInFlags()).toBe(false);
+      expect(httpClientGet).not.toHaveBeenCalled();
+    });
+
+    it("reports missing bootstrapped opt-in metadata as loading until refresh succeeds", async () => {
+      const response = deferred<HttpResponse>();
+      server.use(
+        http.get(
+          "https://front.reflag.com/features/evaluated",
+          () => response.promise,
+        ),
+      );
+
+      client = new ReflagClient({
+        publishableKey: "test-key-loading-bootstrap-opt-in-metadata",
+        user: { id: "user1" },
+        enableTracking: false,
+        bootstrappedFlags: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+          },
+        },
+      });
+      const loadingUpdated = vi.fn();
+      client.on("optInFlagsLoadingUpdated", loadingUpdated);
+
+      await client.initialize();
+      expect(client.getIsLoadingOptInFlags()).toBe(true);
+      await vi.waitFor(() => expect(httpClientGet).toHaveBeenCalledTimes(1));
+
+      response.resolve(optInEvaluationResponse(2, false));
+
+      await vi.waitFor(() => {
+        expect(client.getIsLoadingOptInFlags()).toBe(false);
+      });
+      expect(client.getOptInFlags()).toHaveLength(1);
+      expect(loadingUpdated).toHaveBeenCalledWith(true);
+      expect(loadingUpdated).toHaveBeenLastCalledWith(false);
+    });
+
+    it("stops loading opt-in flags when the metadata refresh fails", async () => {
+      server.use(
+        http.get("https://front.reflag.com/features/evaluated", () =>
+          HttpResponse.json({ success: false }, { status: 500 }),
+        ),
+      );
+
+      client = new ReflagClient({
+        publishableKey: "test-key-failed-bootstrap-opt-in-metadata",
+        user: { id: "user1" },
+        enableTracking: false,
+        bootstrappedFlags: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+          },
+        },
+      });
+
+      await client.initialize();
+      expect(client.getIsLoadingOptInFlags()).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(client.getIsLoadingOptInFlags()).toBe(false);
+      });
+      expect(httpClientGet).toHaveBeenCalledTimes(1);
+      expect(client.getOptInFlags()).toEqual([]);
+    });
+
+    it("keeps opt-in loading tied to the newest context fetch", async () => {
+      const previousContextResponse = deferred<HttpResponse>();
+      const currentContextResponse = deferred<HttpResponse>();
+      const previousContextSettled = vi.fn();
+
+      server.use(
+        http.get(
+          "https://front.reflag.com/features/evaluated",
+          ({ request }) => {
+            const userId = new URL(request.url).searchParams.get(
+              "context.user.id",
+            );
+            if (userId === "user1") {
+              return previousContextResponse.promise.then((response) => {
+                previousContextSettled();
+                return response;
+              });
+            }
+            return currentContextResponse.promise;
+          },
+        ),
+      );
+
+      client = new ReflagClient({
+        publishableKey: "test-key-opt-in-loading-context-race",
+        user: { id: "user1" },
+        enableTracking: false,
+        bootstrappedFlags: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+          },
+        },
+      });
+      await client.initialize();
+
+      expect(client.getIsLoadingOptInFlags()).toBe(true);
+      await vi.waitFor(() => expect(httpClientGet).toHaveBeenCalledTimes(1));
+
+      const contextUpdate = client.setContext({ user: { id: "user2" } });
+      await vi.waitFor(() => expect(httpClientGet).toHaveBeenCalledTimes(2));
+
+      previousContextResponse.resolve(optInEvaluationResponse(2, false));
+      await vi.waitFor(() => expect(previousContextSettled).toHaveBeenCalled());
+      expect(client.getIsLoadingOptInFlags()).toBe(true);
+
+      currentContextResponse.resolve(optInEvaluationResponse(3, true));
+      await contextUpdate;
+
+      expect(client.getIsLoadingOptInFlags()).toBe(false);
+      expect(client.getContext().user?.id).toBe("user2");
+      expect(client.getOptInFlags()[0]).toMatchObject({
+        userOptedIn: true,
+      });
+    });
+
+    it("uses newly applied bootstrapped metadata and ignores a stale refresh", async () => {
+      const staleResponse = deferred<HttpResponse>();
+      const staleResponseSettled = vi.fn();
+      server.use(
+        http.get("https://front.reflag.com/features/evaluated", () =>
+          staleResponse.promise.then((response) => {
+            staleResponseSettled();
+            return response;
+          }),
+        ),
+      );
+
+      client = new ReflagClient({
+        publishableKey: "test-key-applied-bootstrap-opt-in-metadata",
+        user: { id: "user1" },
+        enableTracking: false,
+        bootstrappedFlags: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+          },
+        },
+      });
+      await client.initialize();
+
+      expect(client.getIsLoadingOptInFlags()).toBe(true);
+      await vi.waitFor(() => expect(httpClientGet).toHaveBeenCalledTimes(1));
+
+      client.applyBootstrappedState({
+        context: { user: { id: "user2" } },
+        flags: optInFlags(true, 3),
+        flagStateVersion: 3,
+      });
+
+      expect(client.getIsLoadingOptInFlags()).toBe(false);
+      expect(client.getOptInFlags()[0]).toMatchObject({
+        userOptedIn: true,
+      });
+
+      staleResponse.resolve(optInEvaluationResponse(2, false));
+      await vi.waitFor(() => expect(staleResponseSettled).toHaveBeenCalled());
+      await vi.waitFor(() =>
+        expect(client["flagsClient"]["optInMetadataRefresh"]).toBeUndefined(),
+      );
+
+      expect(client.getIsLoadingOptInFlags()).toBe(false);
+      expect(client.getOptInFlags()[0]).toMatchObject({
+        userOptedIn: true,
+      });
+    });
+
+    it("does not leave missing opt-in metadata loading while offline", async () => {
+      client = new ReflagClient({
+        publishableKey: "test-key-offline-bootstrap-opt-in-metadata",
+        user: { id: "user1" },
+        enableTracking: false,
+        offline: true,
+        bootstrappedFlags: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+          },
+        },
+      });
+
+      expect(client.getIsLoadingOptInFlags()).toBe(true);
+      await client.initialize();
+      expect(client.getIsLoadingOptInFlags()).toBe(false);
+      expect(httpClientGet).not.toHaveBeenCalled();
+    });
+
     it("waits for the bootstrapped flag state version when refreshing opt-in metadata", async () => {
       let requestedWaitForVersion: string | null = null;
       server.use(

--- a/packages/browser-sdk/test/hooksManager.test.ts
+++ b/packages/browser-sdk/test/hooksManager.test.ts
@@ -51,6 +51,15 @@ describe("HookManager", () => {
     expect(callback).toHaveBeenCalledWith(flags);
   });
 
+  it("should add and trigger `optInFlagsLoadingUpdated` hooks", () => {
+    const callback = vi.fn();
+    hookManager.addHook("optInFlagsLoadingUpdated", callback);
+
+    hookManager.trigger("optInFlagsLoadingUpdated", true);
+
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
   it("should add and trigger `track` hooks", () => {
     const callback = vi.fn();
     const user: UserContext = { id: "user-id", name: "user-name" };

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -688,8 +688,8 @@ function OptInList() {
   const { flags, isLoading } = useOptInFlags();
   const setOptIn = useSetOptIn();
 
-  // This loading check matters when a bootstrapped payload does not contain
-  // browser opt-in metadata and the SDK must fetch it on demand.
+  // This is only true when a bootstrapped payload does not contain browser
+  // opt-in metadata and the SDK must fetch it on demand.
   if (isLoading) {
     return <Spinner />;
   }
@@ -715,7 +715,9 @@ User and company opt-ins are managed independently. Setting `optedIn` to `false`
 
 `setOptIn` returns a promise so you can wait for the new membership state to be synchronized. It resolves after the latest flag state has been applied, the requested membership change has been confirmed, and components using `useOptInFlags()` have been notified. React schedules the resulting render normally, so it may not yet be committed when the promise resolves.
 
-`useOptInFlags()` returns `{ flags, isLoading }`. The loading state is primarily useful when a bootstrapped payload does not contain browser opt-in metadata: the hook automatically requests it once, returns `isLoading: true` while that on-demand request is pending, and updates after the evaluated flags arrive. It returns to `false` after either success or failure. Bootstrapped payloads that already contain complete opt-in metadata report `false` immediately. With a regular `ReflagProvider`, the general `useIsLoading()` hook also covers the initial flags request.
+`useOptInFlags()` returns `{ flags, isLoading }`. `isLoading` is only `true` when a bootstrapped payload does not contain browser opt-in metadata: the hook automatically requests it once, reports loading while that on-demand request is pending, and updates after the evaluated flags arrive. It returns to `false` after either success or failure. Bootstrapped payloads that already contain complete opt-in metadata report `false` immediately.
+
+With a regular `ReflagProvider`, opt-in metadata arrives as part of the normal initial flags request, so `useOptInFlags().isLoading` remains `false`. Use the general `useIsLoading()` hook or the provider's `loadingComponent` for that initial loading state.
 
 `useOptInFlags()` also supports Suspense. It respects the provider-level `suspense` option, or you can enable it for only this hook with `useOptInFlags({ suspense: true })`. While required opt-in metadata is loading, the nearest `<Suspense>` boundary renders its fallback:
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -602,7 +602,7 @@ function App({ bootstrapData }: AppProps) {
 > [!Note]
 > When using `ReflagBootstrappedProvider`, pass the entire object returned by `getFlagsForBootstrap()` directly as the `flags` prop. The context is extracted from `flags.context`, and `flags.flagStateVersion` is used when present.
 >
-> The bootstrap payload is used synchronously for SSR and the initial client render. If `useOptInFlags()` is used and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. During that refresh, `useOptInFlags()` returns `isLoading: true`, or suspends when Suspense is enabled. Applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use and the loading state returns to `false`.
+> If bootstrap data omits opt-in metadata, `useOptInFlags()` triggers one flags refresh and returns `isLoading: true` (or suspends) until it settles. No request is made unless the hook is used.
 >
 > If you want live flag updates to continue working after bootstrapping, use a recent `@reflag/node-sdk` so `getFlagsForBootstrap()` includes `flagStateVersion`.
 >

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -602,7 +602,7 @@ function App({ bootstrapData }: AppProps) {
 > [!Note]
 > When using `ReflagBootstrappedProvider`, pass the entire object returned by `getFlagsForBootstrap()` directly as the `flags` prop. The context is extracted from `flags.context`, and `flags.flagStateVersion` is used when present.
 >
-> If bootstrap data omits opt-in metadata, `useOptInFlags()` triggers one flags refresh and returns `isLoading: true` (or suspends) until it settles. No request is made unless the hook is used.
+> With `ReflagBootstrappedProvider`, `useOptInFlags()` triggers one flags refresh and returns `isLoading: true` (or suspends) until it settles. No refresh occurs unless the hook is used.
 >
 > If you want live flag updates to continue working after bootstrapping, use a recent `@reflag/node-sdk` so `getFlagsForBootstrap()` includes `flagStateVersion`.
 >
@@ -688,8 +688,8 @@ function OptInList() {
   const { flags, isLoading } = useOptInFlags();
   const setOptIn = useSetOptIn();
 
-  // This is only true when a bootstrapped payload does not contain browser
-  // opt-in metadata and the SDK must fetch it on demand.
+  // This is only true with ReflagBootstrappedProvider while the SDK fetches
+  // opt-in metadata on first use.
   if (isLoading) {
     return <Spinner />;
   }
@@ -715,7 +715,7 @@ User and company opt-ins are managed independently. Setting `optedIn` to `false`
 
 `setOptIn` returns a promise so you can wait for the new membership state to be synchronized. It resolves after the latest flag state has been applied, the requested membership change has been confirmed, and components using `useOptInFlags()` have been notified. React schedules the resulting render normally, so it may not yet be committed when the promise resolves.
 
-`useOptInFlags()` returns `{ flags, isLoading }`. `isLoading` is only `true` when a bootstrapped payload does not contain browser opt-in metadata: the hook automatically requests it once, reports loading while that on-demand request is pending, and updates after the evaluated flags arrive. It returns to `false` after either success or failure. Bootstrapped payloads that already contain complete opt-in metadata report `false` immediately.
+`useOptInFlags()` returns `{ flags, isLoading }`. With `ReflagBootstrappedProvider`, the hook fetches opt-in metadata on first use and reports `isLoading: true` until the flags refresh succeeds or fails.
 
 With a regular `ReflagProvider`, opt-in metadata arrives as part of the normal initial flags request, so `useOptInFlags().isLoading` remains `false`. Use the general `useIsLoading()` hook or the provider's `loadingComponent` for that initial loading state.
 
@@ -731,7 +731,7 @@ import { Suspense } from "react";
 </ReflagBootstrappedProvider>;
 ```
 
-Suspense is primarily relevant when bootstrapping from a server payload that lacks browser opt-in metadata. Use `useOptInFlags({ suspense: false })` to opt out for one call when Suspense is enabled on the provider.
+Opt-in metadata Suspense is primarily relevant with `ReflagBootstrappedProvider`. Use `useOptInFlags({ suspense: false })` to opt out for one call when Suspense is enabled on the provider.
 
 ### `useTrack()`
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -602,7 +602,7 @@ function App({ bootstrapData }: AppProps) {
 > [!Note]
 > When using `ReflagBootstrappedProvider`, pass the entire object returned by `getFlagsForBootstrap()` directly as the `flags` prop. The context is extracted from `flags.context`, and `flags.flagStateVersion` is used when present.
 >
-> The bootstrap payload is used synchronously for SSR and the initial client render. If `useOptInFlags()` is used and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. During that refresh, `useIsLoadingOptInFlags()` returns `true`, and `useOptInFlags()` suspends when Suspense is enabled. Applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use and the loading state returns to `false`.
+> The bootstrap payload is used synchronously for SSR and the initial client render. If `useOptInFlags()` is used and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. During that refresh, `useOptInFlags()` returns `isLoading: true`, or suspends when Suspense is enabled. Applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use and the loading state returns to `false`.
 >
 > If you want live flag updates to continue working after bootstrapping, use a recent `@reflag/node-sdk` so `getFlagsForBootstrap()` includes `flagStateVersion`.
 >
@@ -677,20 +677,15 @@ import { ReflagProvider } from "@reflag/react-sdk";
 
 You can also opt in for a single call with `useFlag("huddle", { suspense: true })`, or opt out inside a suspense-enabled provider with `{ suspense: false }`.
 
-### `useOptInFlags()`, `useIsLoadingOptInFlags()`, and `useSetOptIn()`
+### `useOptInFlags()` and `useSetOptIn()`
 
 Use these hooks to build an end-user opt-in UI for flags where opt-in is enabled in Reflag.
 
 ```tsx
-import {
-  useIsLoadingOptInFlags,
-  useOptInFlags,
-  useSetOptIn,
-} from "@reflag/react-sdk";
+import { useOptInFlags, useSetOptIn } from "@reflag/react-sdk";
 
 function OptInList() {
-  const optInFlags = useOptInFlags();
-  const isLoading = useIsLoadingOptInFlags();
+  const { flags, isLoading } = useOptInFlags();
   const setOptIn = useSetOptIn();
 
   // This loading check matters when a bootstrapped payload does not contain
@@ -699,11 +694,11 @@ function OptInList() {
     return <Spinner />;
   }
 
-  if (optInFlags.length === 0) {
+  if (flags.length === 0) {
     return <p>No opt-in flags are available.</p>;
   }
 
-  return optInFlags.map((flag) => (
+  return flags.map((flag) => (
     <button
       key={flag.key}
       onClick={() => setOptIn(flag.key, { optedIn: !flag.userOptedIn })}
@@ -720,7 +715,7 @@ User and company opt-ins are managed independently. Setting `optedIn` to `false`
 
 `setOptIn` returns a promise so you can wait for the new membership state to be synchronized. It resolves after the latest flag state has been applied, the requested membership change has been confirmed, and components using `useOptInFlags()` have been notified. React schedules the resulting render normally, so it may not yet be committed when the promise resolves.
 
-When a bootstrapped payload does not contain browser opt-in metadata, `useOptInFlags()` automatically requests it once and updates after the evaluated flags arrive. `useIsLoadingOptInFlags()` is intended for this bootstrapping case: it is `true` while that on-demand request is pending and returns to `false` after either success or failure. Bootstrapped payloads that already contain complete opt-in metadata report `false` immediately.
+`useOptInFlags()` returns `{ flags, isLoading }`. The loading state is primarily useful when a bootstrapped payload does not contain browser opt-in metadata: the hook automatically requests it once, returns `isLoading: true` while that on-demand request is pending, and updates after the evaluated flags arrive. It returns to `false` after either success or failure. Bootstrapped payloads that already contain complete opt-in metadata report `false` immediately. With a regular `ReflagProvider`, the general `useIsLoading()` hook also covers the initial flags request.
 
 `useOptInFlags()` also supports Suspense. It respects the provider-level `suspense` option, or you can enable it for only this hook with `useOptInFlags({ suspense: true })`. While required opt-in metadata is loading, the nearest `<Suspense>` boundary renders its fallback:
 

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -552,7 +552,7 @@ The `<ReflagProvider>` initializes the Reflag SDK, fetches flags and starts list
 - `staleTimeMs`: Maximum time (in milliseconds) that stale flags will be returned if `staleWhileRevalidate` is true and new flags cannot be fetched.
 - `offline`: Provide this option when testing or in local development environments to avoid contacting Reflag servers.
 - `loadingComponent` lets you specify an React component to be rendered instead of the children while the Reflag provider is initializing. If you want more control over loading screens, `useFlag()` and `useIsLoading` returns `isLoading` which you can use to customize the loading experience.
-- `suspense`: Set to `true` to make `useFlag()` suspend while the provider is loading. Wrap components that call `useFlag()` in React `<Suspense>` boundaries and omit `loadingComponent` if you want Suspense fallbacks to control loading UI.
+- `suspense`: Set to `true` to make `useFlag()` suspend while the provider is loading and `useOptInFlags()` suspend while required opt-in metadata is loading. Wrap components that call these hooks in React `<Suspense>` boundaries and omit `loadingComponent` if you want Suspense fallbacks to control loading UI.
 - `enableTracking`: Set to `false` to stop sending tracking events and user/company updates to Reflag. Useful when you're impersonating a user (defaults to `true`),
 - `enableLiveFlagUpdates`: Enables live flag updates over SSE. Defaults to `true` in the React SDK.
 - `apiBaseUrl`: Optional base URL for the Reflag API. This also controls the SSE origin used for live flag updates and automated feedback,
@@ -602,7 +602,7 @@ function App({ bootstrapData }: AppProps) {
 > [!Note]
 > When using `ReflagBootstrappedProvider`, pass the entire object returned by `getFlagsForBootstrap()` directly as the `flags` prop. The context is extracted from `flags.context`, and `flags.flagStateVersion` is used when present.
 >
-> The bootstrap payload is used synchronously for SSR and the initial client render. If `useOptInFlags()` is used and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. Applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use.
+> The bootstrap payload is used synchronously for SSR and the initial client render. If `useOptInFlags()` is used and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. During that refresh, `useIsLoadingOptInFlags()` returns `true`, and `useOptInFlags()` suspends when Suspense is enabled. Applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use and the loading state returns to `false`.
 >
 > If you want live flag updates to continue working after bootstrapping, use a recent `@reflag/node-sdk` so `getFlagsForBootstrap()` includes `flagStateVersion`.
 >
@@ -677,16 +677,31 @@ import { ReflagProvider } from "@reflag/react-sdk";
 
 You can also opt in for a single call with `useFlag("huddle", { suspense: true })`, or opt out inside a suspense-enabled provider with `{ suspense: false }`.
 
-### `useOptInFlags()` and `useSetOptIn()`
+### `useOptInFlags()`, `useIsLoadingOptInFlags()`, and `useSetOptIn()`
 
 Use these hooks to build an end-user opt-in UI for flags where opt-in is enabled in Reflag.
 
 ```tsx
-import { useOptInFlags, useSetOptIn } from "@reflag/react-sdk";
+import {
+  useIsLoadingOptInFlags,
+  useOptInFlags,
+  useSetOptIn,
+} from "@reflag/react-sdk";
 
 function OptInList() {
   const optInFlags = useOptInFlags();
+  const isLoading = useIsLoadingOptInFlags();
   const setOptIn = useSetOptIn();
+
+  // This loading check matters when a bootstrapped payload does not contain
+  // browser opt-in metadata and the SDK must fetch it on demand.
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (optInFlags.length === 0) {
+    return <p>No opt-in flags are available.</p>;
+  }
 
   return optInFlags.map((flag) => (
     <button
@@ -705,7 +720,21 @@ User and company opt-ins are managed independently. Setting `optedIn` to `false`
 
 `setOptIn` returns a promise so you can wait for the new membership state to be synchronized. It resolves after the latest flag state has been applied, the requested membership change has been confirmed, and components using `useOptInFlags()` have been notified. React schedules the resulting render normally, so it may not yet be committed when the promise resolves.
 
-When a bootstrapped payload does not contain browser opt-in metadata, `useOptInFlags()` automatically requests it once and updates after the evaluated flags arrive.
+When a bootstrapped payload does not contain browser opt-in metadata, `useOptInFlags()` automatically requests it once and updates after the evaluated flags arrive. `useIsLoadingOptInFlags()` is intended for this bootstrapping case: it is `true` while that on-demand request is pending and returns to `false` after either success or failure. Bootstrapped payloads that already contain complete opt-in metadata report `false` immediately.
+
+`useOptInFlags()` also supports Suspense. It respects the provider-level `suspense` option, or you can enable it for only this hook with `useOptInFlags({ suspense: true })`. While required opt-in metadata is loading, the nearest `<Suspense>` boundary renders its fallback:
+
+```tsx
+import { Suspense } from "react";
+
+<ReflagBootstrappedProvider publishableKey="..." flags={bootstrapData} suspense>
+  <Suspense fallback={<Spinner />}>
+    <OptInList />
+  </Suspense>
+</ReflagBootstrappedProvider>;
+```
+
+Suspense is primarily relevant when bootstrapping from a server payload that lacks browser opt-in metadata. Use `useOptInFlags({ suspense: false })` to opt out for one call when Suspense is enabled on the provider.
 
 ### `useTrack()`
 

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --project tsconfig.build.json && vite build",
-    "test": "vitest run",
+    "test": "yarn test:types && vitest run",
+    "test:types": "tsc --project tsconfig.type-tests.json",
     "test:watch": "vitest",
     "test:ci": "yarn test --reporter=default --reporter=junit --outputFile=junit.xml",
     "coverage": "yarn test --coverage",

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -18,7 +18,7 @@ import {
   HookArgs,
   InitOptions,
   Logger,
-  OptInFlag,
+  OptInFlag as BrowserOptInFlag,
   RawFlag,
   RawFlags as BrowserRawFlags,
   ReflagClient,
@@ -39,7 +39,6 @@ const useIsomorphicLayoutEffect =
 export type {
   CheckEvent,
   CompanyContext,
-  OptInFlag,
   SetOptInOptions,
   StorageAdapter,
   TrackEvent,
@@ -133,6 +132,13 @@ export type TypedFlags = keyof Flags extends never
 export type FlagKey = keyof TypedFlags;
 
 /**
+ * An opt-in-enabled flag for the generated React SDK flag definitions.
+ */
+export type OptInFlag = Omit<BrowserOptInFlag, "key"> & {
+  key: FlagKey;
+};
+
+/**
  * Describes a collection of evaluated raw flags.
  */
 export type RawFlags = Record<FlagKey, RawFlag>;
@@ -164,8 +170,9 @@ export type ReflagPropsBase = {
   initialLoading?: boolean;
 
   /**
-   * Set to `true` to make `useFlag` suspend while the client is loading.
-   * Components that call `useFlag` must be wrapped in a React `<Suspense>` boundary.
+   * Set to `true` to make `useFlag` and `useOptInFlags` suspend while their
+   * required flag data is loading. Components that call either hook must be
+   * wrapped in a React `<Suspense>` boundary.
    */
   suspense?: boolean;
 
@@ -202,6 +209,10 @@ export type ReflagInitOptionsBase = Omit<
  * @internal
  */
 const reflagClients = new Map<string, ReflagClient>();
+const reflagClientBootstrappedStates = new WeakMap<
+  ReflagClient,
+  BrowserBootstrappedState
+>();
 
 function contextPartEqual(
   a?: Record<string, string | number | undefined>,
@@ -250,6 +261,12 @@ function useReflagClient(initOptions: InitOptions & { debug?: boolean }) {
       logger: logger ?? (debug ? console : undefined),
       sdkVersion: sdkVersion ?? SDK_VERSION,
     });
+    if (clientOptions.bootstrappedState) {
+      reflagClientBootstrappedStates.set(
+        client,
+        clientOptions.bootstrappedState,
+      );
+    }
     if (!isServer) {
       reflagClients.set(publishableKey, client);
     }
@@ -295,6 +312,45 @@ function createLoadingPromise(client: ReflagClient): LoadingPromiseState {
   });
 
   return { promise, resolve };
+}
+
+const optInFlagsLoadingPromises = new WeakMap<ReflagClient, Promise<void>>();
+
+function getOptInFlagsLoadingPromise(client: ReflagClient) {
+  const existingPromise = optInFlagsLoadingPromises.get(client);
+  if (existingPromise) return existingPromise;
+
+  let unsubscribe: (() => void) | undefined;
+  const promise = new Promise<void>((resolve) => {
+    const finish = () => {
+      unsubscribe?.();
+      resolve();
+    };
+
+    unsubscribe = client.on("optInFlagsLoadingUpdated", (isLoading) => {
+      if (!isLoading) finish();
+    });
+
+    if (!client.getIsLoadingOptInFlags()) finish();
+  });
+
+  optInFlagsLoadingPromises.set(client, promise);
+  void promise.then(() => {
+    if (optInFlagsLoadingPromises.get(client) === promise) {
+      optInFlagsLoadingPromises.delete(client);
+    }
+  });
+
+  if (client.getState() === "idle") {
+    void Promise.resolve().then(() => {
+      if (client.getState() !== "idle") return;
+      return client.initialize().catch((error) => {
+        client.logger.error("failed to initialize client", error);
+      });
+    });
+  }
+
+  return promise;
 }
 
 type ProviderContextType = {
@@ -538,6 +594,9 @@ export function ReflagBootstrappedProvider({
 
   // Update the bootstrapped state if it changes on the client side
   useEffect(() => {
+    if (reflagClientBootstrappedStates.get(client) === flags) return;
+
+    reflagClientBootstrappedStates.set(client, flags);
     client.applyBootstrappedState(flags);
   }, [client, flags]);
 
@@ -562,6 +621,14 @@ export type UseFlagOptions = {
   /**
    * Override the provider suspense setting for this `useFlag` call.
    * When true, `useFlag` throws a promise while flags are loading.
+   */
+  suspense?: boolean;
+};
+
+export type UseOptInFlagsOptions = {
+  /**
+   * Override the provider suspense setting for this `useOptInFlags` call.
+   * When true, `useOptInFlags` throws a promise while opt-in flags are loading.
    */
   suspense?: boolean;
 };
@@ -645,20 +712,51 @@ export function useFlag<TKey extends FlagKey>(
 
 /**
  * Returns opt-in-enabled flags for the current context.
+ *
+ * When suspense is enabled for the provider or this hook, it suspends while
+ * initial flags or required opt-in metadata are loading.
  */
-export function useOptInFlags(): OptInFlag[] {
-  const client = useClient();
-  const [optInFlags, setOptInFlags] = useState(client.getOptInFlags());
+export function useOptInFlags(options: UseOptInFlagsOptions = {}): OptInFlag[] {
+  const context = useSafeContext();
+  const { client } = context;
+  const isLoading = useIsLoadingOptInFlags();
+  const getOptInFlags = () => client.getOptInFlags() as OptInFlag[];
+  const [optInFlags, setOptInFlags] = useState(getOptInFlags);
 
   useOnEvent(
     "flagsUpdated",
     () => {
-      setOptInFlags(client.getOptInFlags());
+      setOptInFlags(getOptInFlags());
     },
     client,
   );
 
+  if (isLoading && (options.suspense ?? context.suspense)) {
+    throw getOptInFlagsLoadingPromise(client);
+  }
+
   return optInFlags;
+}
+
+/**
+ * Returns whether opt-in flags are loading for the current context.
+ *
+ * This is primarily useful with `ReflagBootstrappedProvider` when the bootstrap
+ * payload does not contain browser opt-in metadata and it is fetched on demand.
+ */
+export function useIsLoadingOptInFlags(): boolean {
+  const { client } = useSafeContext();
+  const [isLoading, setIsLoading] = useState(() =>
+    client.getIsLoadingOptInFlags(),
+  );
+
+  useOnEvent("optInFlagsLoadingUpdated", setIsLoading, client);
+
+  useIsomorphicLayoutEffect(() => {
+    setIsLoading(client.getIsLoadingOptInFlags());
+  }, [client]);
+
+  return isLoading;
 }
 
 /**

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -640,7 +640,7 @@ export type UseOptInFlagsResult = {
   flags: OptInFlag[];
 
   /**
-   * Whether initial flags or required opt-in metadata are loading.
+   * Whether opt-in metadata missing from a bootstrapped payload is loading.
    */
   isLoading: boolean;
 };
@@ -725,10 +725,11 @@ export function useFlag<TKey extends FlagKey>(
 /**
  * Returns opt-in-enabled flags and their loading state for the current context.
  *
- * The loading state is primarily useful with `ReflagBootstrappedProvider` when
- * the bootstrap payload does not contain browser opt-in metadata and it is
- * fetched on demand. When suspense is enabled for the provider or this hook,
- * it suspends instead of returning a loading result.
+ * The loading state is only used with `ReflagBootstrappedProvider` when the
+ * bootstrap payload does not contain browser opt-in metadata and it is fetched
+ * on demand. Regular providers load opt-in metadata with the initial flags.
+ * When suspense is enabled for the provider or this hook, it suspends instead
+ * of returning a loading result.
  */
 export function useOptInFlags(
   options: UseOptInFlagsOptions = {},
@@ -737,7 +738,8 @@ export function useOptInFlags(
   const { client } = context;
   const getOptInFlags = () => client.getOptInFlags() as OptInFlag[];
   const [flags, setFlags] = useState(getOptInFlags);
-  const [isLoading, setIsLoading] = useState(() =>
+  const isBootstrapped = client.getConfig().bootstrapped;
+  const [isOptInFlagsLoading, setIsOptInFlagsLoading] = useState(() =>
     client.getIsLoadingOptInFlags(),
   );
 
@@ -748,13 +750,19 @@ export function useOptInFlags(
     },
     client,
   );
-  useOnEvent("optInFlagsLoadingUpdated", setIsLoading, client);
+  useOnEvent("optInFlagsLoadingUpdated", setIsOptInFlagsLoading, client);
 
   useIsomorphicLayoutEffect(() => {
-    setIsLoading(client.getIsLoadingOptInFlags());
+    setIsOptInFlagsLoading(client.getIsLoadingOptInFlags());
   }, [client]);
 
-  if (isLoading && (options.suspense ?? context.suspense)) {
+  const suspense = options.suspense ?? context.suspense;
+  if (suspense && context.isLoading && isClientLoading(client)) {
+    throw context.getLoadingPromise();
+  }
+
+  const isLoading = isBootstrapped && isOptInFlagsLoading;
+  if (suspense && isLoading) {
     throw getOptInFlagsLoadingPromise(client);
   }
 

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -558,8 +558,8 @@ export function ReflagProvider({
 export type ReflagBootstrappedProps = ReflagPropsBase &
   ReflagInitOptionsBase & {
     /**
-     * Pre-fetched flags used for the initial render. If opt-in flags are requested and
-     * browser opt-in metadata is missing, the browser client refreshes them on demand.
+     * Pre-fetched flags used for the initial render. The browser client fetches opt-in
+     * metadata on demand when opt-in flags are requested.
      */
     flags: BootstrappedFlags;
   };
@@ -640,7 +640,7 @@ export type UseOptInFlagsResult = {
   flags: OptInFlag[];
 
   /**
-   * Whether opt-in metadata missing from a bootstrapped payload is loading.
+   * Whether a bootstrapped provider is fetching opt-in metadata.
    */
   isLoading: boolean;
 };
@@ -725,9 +725,9 @@ export function useFlag<TKey extends FlagKey>(
 /**
  * Returns opt-in-enabled flags and their loading state for the current context.
  *
- * The loading state is only used with `ReflagBootstrappedProvider` when the
- * bootstrap payload does not contain browser opt-in metadata and it is fetched
- * on demand. Regular providers load opt-in metadata with the initial flags.
+ * The loading state is only used with `ReflagBootstrappedProvider` while
+ * opt-in metadata is fetched on demand. Regular providers load opt-in metadata
+ * with the initial flags.
  * When suspense is enabled for the provider or this hook, it suspends instead
  * of returning a loading result.
  */

--- a/packages/react-sdk/src/index.tsx
+++ b/packages/react-sdk/src/index.tsx
@@ -633,6 +633,18 @@ export type UseOptInFlagsOptions = {
   suspense?: boolean;
 };
 
+export type UseOptInFlagsResult = {
+  /**
+   * Opt-in-enabled flags for the current context.
+   */
+  flags: OptInFlag[];
+
+  /**
+   * Whether initial flags or required opt-in metadata are loading.
+   */
+  isLoading: boolean;
+};
+
 /**
  * @deprecated use `useFlag` instead
  */
@@ -711,52 +723,42 @@ export function useFlag<TKey extends FlagKey>(
 }
 
 /**
- * Returns opt-in-enabled flags for the current context.
+ * Returns opt-in-enabled flags and their loading state for the current context.
  *
- * When suspense is enabled for the provider or this hook, it suspends while
- * initial flags or required opt-in metadata are loading.
+ * The loading state is primarily useful with `ReflagBootstrappedProvider` when
+ * the bootstrap payload does not contain browser opt-in metadata and it is
+ * fetched on demand. When suspense is enabled for the provider or this hook,
+ * it suspends instead of returning a loading result.
  */
-export function useOptInFlags(options: UseOptInFlagsOptions = {}): OptInFlag[] {
+export function useOptInFlags(
+  options: UseOptInFlagsOptions = {},
+): UseOptInFlagsResult {
   const context = useSafeContext();
   const { client } = context;
-  const isLoading = useIsLoadingOptInFlags();
   const getOptInFlags = () => client.getOptInFlags() as OptInFlag[];
-  const [optInFlags, setOptInFlags] = useState(getOptInFlags);
-
-  useOnEvent(
-    "flagsUpdated",
-    () => {
-      setOptInFlags(getOptInFlags());
-    },
-    client,
-  );
-
-  if (isLoading && (options.suspense ?? context.suspense)) {
-    throw getOptInFlagsLoadingPromise(client);
-  }
-
-  return optInFlags;
-}
-
-/**
- * Returns whether opt-in flags are loading for the current context.
- *
- * This is primarily useful with `ReflagBootstrappedProvider` when the bootstrap
- * payload does not contain browser opt-in metadata and it is fetched on demand.
- */
-export function useIsLoadingOptInFlags(): boolean {
-  const { client } = useSafeContext();
+  const [flags, setFlags] = useState(getOptInFlags);
   const [isLoading, setIsLoading] = useState(() =>
     client.getIsLoadingOptInFlags(),
   );
 
+  useOnEvent(
+    "flagsUpdated",
+    () => {
+      setFlags(getOptInFlags());
+    },
+    client,
+  );
   useOnEvent("optInFlagsLoadingUpdated", setIsLoading, client);
 
   useIsomorphicLayoutEffect(() => {
     setIsLoading(client.getIsLoadingOptInFlags());
   }, [client]);
 
-  return isLoading;
+  if (isLoading && (options.suspense ?? context.suspense)) {
+    throw getOptInFlagsLoadingPromise(client);
+  }
+
+  return { flags, isLoading };
 }
 
 /**

--- a/packages/react-sdk/test/opt-in-types.tsx
+++ b/packages/react-sdk/test/opt-in-types.tsx
@@ -7,10 +7,10 @@ declare module "@reflag/react-sdk" {
 }
 
 export function GeneratedOptInTypes() {
-  const optInFlags = useOptInFlags();
+  const { flags } = useOptInFlags();
   const setOptIn = useSetOptIn();
 
-  for (const flag of optInFlags) {
+  for (const flag of flags) {
     void setOptIn(flag.key, { optedIn: !flag.userOptedIn });
   }
 

--- a/packages/react-sdk/test/opt-in-types.tsx
+++ b/packages/react-sdk/test/opt-in-types.tsx
@@ -1,0 +1,21 @@
+import { useOptInFlags, useSetOptIn } from "@reflag/react-sdk";
+
+declare module "@reflag/react-sdk" {
+  interface Flags {
+    "generated-opt-in-flag": {};
+  }
+}
+
+export function GeneratedOptInTypes() {
+  const optInFlags = useOptInFlags();
+  const setOptIn = useSetOptIn();
+
+  for (const flag of optInFlags) {
+    void setOptIn(flag.key, { optedIn: !flag.userOptedIn });
+  }
+
+  // @ts-expect-error generated flag types still reject unknown literal keys
+  void setOptIn("unknown-flag", { optedIn: true });
+
+  return null;
+}

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -26,7 +26,6 @@ import {
   useClient,
   useFlag,
   useIsLoading,
-  useIsLoadingOptInFlags,
   useOnEvent,
   useOptInFlags,
   useRequestFeedback,
@@ -1099,19 +1098,13 @@ describe("opt-in hooks", () => {
       },
     };
 
-    const { result, unmount } = renderHook(
-      () => ({
-        isLoading: useIsLoadingOptInFlags(),
-        optInFlags: useOptInFlags(),
-      }),
-      {
-        wrapper: ({ children }) =>
-          getBootstrapProvider(bootstrapFlags, { children }),
-      },
-    );
+    const { result, unmount } = renderHook(() => useOptInFlags(), {
+      wrapper: ({ children }) =>
+        getBootstrapProvider(bootstrapFlags, { children }),
+    });
 
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.optInFlags).toHaveLength(1);
+    expect(result.current.flags).toHaveLength(1);
     unmount();
   });
 
@@ -1143,10 +1136,9 @@ describe("opt-in hooks", () => {
 
     const { result, unmount } = renderHook(
       () => {
-        const isLoading = useIsLoadingOptInFlags();
-        const optInFlags = useOptInFlags();
-        loadingRenders.push(isLoading);
-        return { isLoading, optInFlags };
+        const state = useOptInFlags();
+        loadingRenders.push(state.isLoading);
+        return state;
       },
       {
         wrapper: ({ children }) =>
@@ -1154,7 +1146,7 @@ describe("opt-in hooks", () => {
       },
     );
 
-    expect(result.current).toEqual({ isLoading: true, optInFlags: [] });
+    expect(result.current).toEqual({ isLoading: true, flags: [] });
     await waitFor(() => expect(requestStarted).toHaveBeenCalledOnce());
 
     resolveResponse(
@@ -1181,7 +1173,7 @@ describe("opt-in hooks", () => {
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
-      expect(result.current.optInFlags).toHaveLength(1);
+      expect(result.current.flags).toHaveLength(1);
     });
     expect(loadingRenders).toContain(true);
     expect(loadingRenders).toContain(false);
@@ -1206,20 +1198,14 @@ describe("opt-in hooks", () => {
       },
     };
 
-    const { result, unmount } = renderHook(
-      () => ({
-        isLoading: useIsLoadingOptInFlags(),
-        optInFlags: useOptInFlags(),
-      }),
-      {
-        wrapper: ({ children }) =>
-          getBootstrapProvider(bootstrapFlags, { children }),
-      },
-    );
+    const { result, unmount } = renderHook(() => useOptInFlags(), {
+      wrapper: ({ children }) =>
+        getBootstrapProvider(bootstrapFlags, { children }),
+    });
 
     expect(result.current.isLoading).toBe(true);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.optInFlags).toEqual([]);
+    expect(result.current.flags).toEqual([]);
     unmount();
   });
 
@@ -1248,8 +1234,8 @@ describe("opt-in hooks", () => {
     };
 
     function OptInList() {
-      const optInFlags = useOptInFlags();
-      return <span data-testid="opt-in-count">{optInFlags.length}</span>;
+      const { flags } = useOptInFlags();
+      return <span data-testid="opt-in-count">{flags.length}</span>;
     }
 
     const { getByTestId, queryByTestId, unmount } = render(
@@ -1324,7 +1310,7 @@ describe("opt-in hooks", () => {
     };
 
     const { result, unmount } = renderHook(
-      () => ({ client: useClient(), optInFlags: useOptInFlags() }),
+      () => ({ client: useClient(), optInState: useOptInFlags() }),
       {
         wrapper: ({ children }) =>
           getBootstrapProvider(bootstrapFlags, { children }),
@@ -1332,7 +1318,7 @@ describe("opt-in hooks", () => {
     );
 
     await waitFor(() => {
-      expect(result.current.optInFlags).toEqual([
+      expect(result.current.optInState.flags).toEqual([
         {
           key: "optInFlag",
           name: "Opt-in flag",
@@ -1364,7 +1350,7 @@ describe("opt-in hooks", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.optInFlags).toEqual([
+      expect(result.current.optInState.flags).toEqual([
         {
           key: "optInFlag",
           name: "Opt-in flag",
@@ -1426,17 +1412,20 @@ describe("opt-in hooks", () => {
 
     await waitFor(() => expect(evaluatedRequests).toBe(1));
     await waitFor(() => {
-      expect(result.current).toEqual([
-        {
-          key: "optInFlag",
-          name: "Opt-in flag",
-          description: "Try it early",
-          isEnabled: false,
-          userOptedIn: false,
-          companyOptedIn: false,
-          isOptedIn: false,
-        },
-      ]);
+      expect(result.current).toEqual({
+        isLoading: false,
+        flags: [
+          {
+            key: "optInFlag",
+            name: "Opt-in flag",
+            description: "Try it early",
+            isEnabled: false,
+            userOptedIn: false,
+            companyOptedIn: false,
+            isOptedIn: false,
+          },
+        ],
+      });
     });
     expect(evaluatedRequests).toBe(1);
 

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -26,6 +26,7 @@ import {
   useClient,
   useFlag,
   useIsLoading,
+  useIsLoadingOptInFlags,
   useOnEvent,
   useOptInFlags,
   useRequestFeedback,
@@ -1078,6 +1079,223 @@ describe("useFlag with ReflagBootstrappedProvider", () => {
 });
 
 describe("opt-in hooks", () => {
+  test("complete bootstrapped metadata is not loading", () => {
+    const bootstrapFlags: BootstrappedFlags = {
+      context: { user, company, other },
+      flags: {
+        optInFlag: {
+          key: "optInFlag",
+          isEnabled: false,
+          targetingVersion: 1,
+          optInEnabled: true,
+          optIn: {
+            userOptedIn: false,
+            companyOptedIn: false,
+            isOptedIn: false,
+            name: "Opt-in flag",
+            description: "Try it early",
+          },
+        },
+      },
+    };
+
+    const { result, unmount } = renderHook(
+      () => ({
+        isLoading: useIsLoadingOptInFlags(),
+        optInFlags: useOptInFlags(),
+      }),
+      {
+        wrapper: ({ children }) =>
+          getBootstrapProvider(bootstrapFlags, { children }),
+      },
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.optInFlags).toHaveLength(1);
+    unmount();
+  });
+
+  test("rerenders while missing bootstrapped metadata refreshes successfully", async () => {
+    let resolveResponse!: (response: HttpResponse) => void;
+    const response = new Promise<HttpResponse>((resolve) => {
+      resolveResponse = resolve;
+    });
+    const requestStarted = vi.fn();
+    server.use(
+      http.get(/\/features\/evaluated$/, () => {
+        requestStarted();
+        return response;
+      }),
+    );
+
+    const bootstrapFlags: BootstrappedFlags = {
+      context: { user, company, other },
+      flagStateVersion: 1,
+      flags: {
+        optInFlag: {
+          key: "optInFlag",
+          isEnabled: false,
+          targetingVersion: 1,
+        },
+      },
+    };
+    const loadingRenders: boolean[] = [];
+
+    const { result, unmount } = renderHook(
+      () => {
+        const isLoading = useIsLoadingOptInFlags();
+        const optInFlags = useOptInFlags();
+        loadingRenders.push(isLoading);
+        return { isLoading, optInFlags };
+      },
+      {
+        wrapper: ({ children }) =>
+          getBootstrapProvider(bootstrapFlags, { children }),
+      },
+    );
+
+    expect(result.current).toEqual({ isLoading: true, optInFlags: [] });
+    await waitFor(() => expect(requestStarted).toHaveBeenCalledOnce());
+
+    resolveResponse(
+      HttpResponse.json({
+        success: true,
+        flagStateVersion: 2,
+        features: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+            optInEnabled: true,
+            optIn: {
+              userOptedIn: false,
+              companyOptedIn: false,
+              isOptedIn: false,
+              name: "Opt-in flag",
+              description: "Try it early",
+            },
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.optInFlags).toHaveLength(1);
+    });
+    expect(loadingRenders).toContain(true);
+    expect(loadingRenders).toContain(false);
+    unmount();
+  });
+
+  test("stops loading when a bootstrapped metadata refresh fails", async () => {
+    server.use(
+      http.get(/\/features\/evaluated$/, () =>
+        HttpResponse.json({ success: false }, { status: 500 }),
+      ),
+    );
+
+    const bootstrapFlags: BootstrappedFlags = {
+      context: { user, company, other },
+      flags: {
+        optInFlag: {
+          key: "optInFlag",
+          isEnabled: false,
+          targetingVersion: 1,
+        },
+      },
+    };
+
+    const { result, unmount } = renderHook(
+      () => ({
+        isLoading: useIsLoadingOptInFlags(),
+        optInFlags: useOptInFlags(),
+      }),
+      {
+        wrapper: ({ children }) =>
+          getBootstrapProvider(bootstrapFlags, { children }),
+      },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.optInFlags).toEqual([]);
+    unmount();
+  });
+
+  test("useOptInFlags suspends for missing bootstrapped metadata", async () => {
+    let resolveResponse!: (response: HttpResponse) => void;
+    const response = new Promise<HttpResponse>((resolve) => {
+      resolveResponse = resolve;
+    });
+    const requestStarted = vi.fn();
+    server.use(
+      http.get(/\/features\/evaluated$/, () => {
+        requestStarted();
+        return response;
+      }),
+    );
+
+    const bootstrapFlags: BootstrappedFlags = {
+      context: { user, company, other },
+      flags: {
+        optInFlag: {
+          key: "optInFlag",
+          isEnabled: false,
+          targetingVersion: 1,
+        },
+      },
+    };
+
+    function OptInList() {
+      const optInFlags = useOptInFlags();
+      return <span data-testid="opt-in-count">{optInFlags.length}</span>;
+    }
+
+    const { getByTestId, queryByTestId, unmount } = render(
+      <React.Suspense
+        fallback={<span data-testid="opt-in-loading">Loading opt-ins</span>}
+      >
+        {getBootstrapProvider(bootstrapFlags, {
+          suspense: true,
+          children: <OptInList />,
+        })}
+      </React.Suspense>,
+    );
+
+    expect(getByTestId("opt-in-loading").textContent).toBe("Loading opt-ins");
+    expect(queryByTestId("opt-in-count")).toBeNull();
+    await waitFor(() => expect(requestStarted).toHaveBeenCalledOnce());
+
+    resolveResponse(
+      HttpResponse.json({
+        success: true,
+        features: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+            optInEnabled: true,
+            optIn: {
+              userOptedIn: false,
+              companyOptedIn: false,
+              isOptedIn: false,
+              name: "Opt-in flag",
+              description: null,
+            },
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("opt-in-count").textContent).toBe("1");
+    });
+    expect(queryByTestId("opt-in-loading")).toBeNull();
+    expect(requestStarted).toHaveBeenCalledOnce();
+    unmount();
+  });
+
   test("useOptInFlags returns and updates opt-in flags", async () => {
     const bootstrapFlags: BootstrappedFlags = {
       context: { user, company, other },

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -57,6 +57,7 @@ function getProvider(props: Omit<Partial<ReflagProps>, "publishableKey"> = {}) {
     <ReflagProvider
       context={{ user, company, other }}
       publishableKey={publishableKey}
+      toolbar={false}
       {...props}
     />
   );
@@ -71,6 +72,7 @@ function getBootstrapProvider(
     <ReflagBootstrappedProvider
       flags={bootstrapFlags}
       publishableKey={publishableKey}
+      toolbar={false}
       {...props}
     />
   );
@@ -152,6 +154,9 @@ const server = setupServer(
       { status: 200 },
     );
   }),
+  http.post(/\/bulk$/, () => {
+    return HttpResponse.json({ success: true });
+  }),
 );
 
 beforeAll(() =>
@@ -176,7 +181,9 @@ beforeEach(() => {
 
 describe("<ReflagProvider />", () => {
   test("calls initialize", () => {
-    const initialize = vi.spyOn(ReflagClient.prototype, "initialize");
+    const initialize = vi
+      .spyOn(ReflagClient.prototype, "initialize")
+      .mockResolvedValueOnce();
 
     const provider = getProvider({
       apiBaseUrl: "https://apibaseurl.com",

--- a/packages/react-sdk/test/usage.test.tsx
+++ b/packages/react-sdk/test/usage.test.tsx
@@ -1078,6 +1078,125 @@ describe("useFlag with ReflagBootstrappedProvider", () => {
 });
 
 describe("opt-in hooks", () => {
+  test("uses the normal provider loading state for the initial flags request", async () => {
+    let resolveResponse!: (response: HttpResponse) => void;
+    const response = new Promise<HttpResponse>((resolve) => {
+      resolveResponse = resolve;
+    });
+    const requestStarted = vi.fn();
+    server.use(
+      http.get(/\/features\/evaluated$/, () => {
+        requestStarted();
+        return response;
+      }),
+    );
+
+    const { result, unmount } = renderHook(
+      () => ({
+        isLoading: useIsLoading(),
+        optInState: useOptInFlags(),
+      }),
+      {
+        wrapper: ({ children }) => getProvider({ children }),
+      },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.optInState).toEqual({
+      flags: [],
+      isLoading: false,
+    });
+    await waitFor(() => expect(requestStarted).toHaveBeenCalledOnce());
+
+    resolveResponse(
+      HttpResponse.json({
+        success: true,
+        features: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+            optInEnabled: true,
+            optIn: {
+              userOptedIn: false,
+              companyOptedIn: false,
+              isOptedIn: false,
+              name: "Opt-in flag",
+              description: null,
+            },
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.optInState).toEqual({
+        flags: [expect.objectContaining({ key: "optInFlag" })],
+        isLoading: false,
+      });
+    });
+    unmount();
+  });
+
+  test("suspends with a regular provider during the initial flags request", async () => {
+    let resolveResponse!: (response: HttpResponse) => void;
+    const response = new Promise<HttpResponse>((resolve) => {
+      resolveResponse = resolve;
+    });
+    const requestStarted = vi.fn();
+    server.use(
+      http.get(/\/features\/evaluated$/, () => {
+        requestStarted();
+        return response;
+      }),
+    );
+
+    function OptInList() {
+      const { flags } = useOptInFlags();
+      return <span data-testid="regular-opt-in-count">{flags.length}</span>;
+    }
+
+    const { getByTestId, queryByTestId, unmount } = render(
+      <React.Suspense
+        fallback={<span data-testid="regular-opt-in-loading">Loading</span>}
+      >
+        {getProvider({ suspense: true, children: <OptInList /> })}
+      </React.Suspense>,
+    );
+
+    expect(getByTestId("regular-opt-in-loading").textContent).toBe("Loading");
+    expect(queryByTestId("regular-opt-in-count")).toBeNull();
+    await waitFor(() => expect(requestStarted).toHaveBeenCalledOnce());
+
+    resolveResponse(
+      HttpResponse.json({
+        success: true,
+        features: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+            optInEnabled: true,
+            optIn: {
+              userOptedIn: false,
+              companyOptedIn: false,
+              isOptedIn: false,
+              name: "Opt-in flag",
+              description: null,
+            },
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("regular-opt-in-count").textContent).toBe("1");
+    });
+    expect(queryByTestId("regular-opt-in-loading")).toBeNull();
+    unmount();
+  });
+
   test("complete bootstrapped metadata is not loading", () => {
     const bootstrapFlags: BootstrappedFlags = {
       context: { user, company, other },
@@ -1209,6 +1328,49 @@ describe("opt-in hooks", () => {
     unmount();
   });
 
+  test("stops suspending when a bootstrapped metadata refresh fails", async () => {
+    server.use(
+      http.get(/\/features\/evaluated$/, () =>
+        HttpResponse.json({ success: false }, { status: 500 }),
+      ),
+    );
+
+    const bootstrapFlags: BootstrappedFlags = {
+      context: { user, company, other },
+      flags: {
+        optInFlag: {
+          key: "optInFlag",
+          isEnabled: false,
+          targetingVersion: 1,
+        },
+      },
+    };
+
+    function OptInList() {
+      const { flags } = useOptInFlags();
+      return <span data-testid="failed-opt-in-count">{flags.length}</span>;
+    }
+
+    const { getByTestId, queryByTestId, unmount } = render(
+      <React.Suspense
+        fallback={<span data-testid="failed-opt-in-loading">Loading</span>}
+      >
+        {getBootstrapProvider(bootstrapFlags, {
+          suspense: true,
+          children: <OptInList />,
+        })}
+      </React.Suspense>,
+    );
+
+    expect(getByTestId("failed-opt-in-loading").textContent).toBe("Loading");
+
+    await waitFor(() => {
+      expect(getByTestId("failed-opt-in-count").textContent).toBe("0");
+    });
+    expect(queryByTestId("failed-opt-in-loading")).toBeNull();
+    unmount();
+  });
+
   test("useOptInFlags suspends for missing bootstrapped metadata", async () => {
     let resolveResponse!: (response: HttpResponse) => void;
     const response = new Promise<HttpResponse>((resolve) => {
@@ -1279,6 +1441,74 @@ describe("opt-in hooks", () => {
     });
     expect(queryByTestId("opt-in-loading")).toBeNull();
     expect(requestStarted).toHaveBeenCalledOnce();
+    unmount();
+  });
+
+  test("can opt out of provider Suspense for opt-in metadata", async () => {
+    let resolveResponse!: (response: HttpResponse) => void;
+    const response = new Promise<HttpResponse>((resolve) => {
+      resolveResponse = resolve;
+    });
+    server.use(http.get(/\/features\/evaluated$/, () => response));
+
+    const bootstrapFlags: BootstrappedFlags = {
+      context: { user, company, other },
+      flags: {
+        optInFlag: {
+          key: "optInFlag",
+          isEnabled: false,
+          targetingVersion: 1,
+        },
+      },
+    };
+
+    function OptInList() {
+      const { flags, isLoading } = useOptInFlags({ suspense: false });
+      return (
+        <span data-testid="opt-in-state">
+          {String(isLoading)}:{flags.length}
+        </span>
+      );
+    }
+
+    const { getByTestId, queryByTestId, unmount } = render(
+      <React.Suspense
+        fallback={<span data-testid="opt-in-loading">Loading opt-ins</span>}
+      >
+        {getBootstrapProvider(bootstrapFlags, {
+          suspense: true,
+          children: <OptInList />,
+        })}
+      </React.Suspense>,
+    );
+
+    expect(queryByTestId("opt-in-loading")).toBeNull();
+    expect(getByTestId("opt-in-state").textContent).toBe("true:0");
+
+    resolveResponse(
+      HttpResponse.json({
+        success: true,
+        features: {
+          optInFlag: {
+            key: "optInFlag",
+            isEnabled: false,
+            targetingVersion: 1,
+            optInEnabled: true,
+            optIn: {
+              userOptedIn: false,
+              companyOptedIn: false,
+              isOptedIn: false,
+              name: "Opt-in flag",
+              description: null,
+            },
+          },
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("opt-in-state").textContent).toBe("false:1");
+    });
     unmount();
   });
 

--- a/packages/react-sdk/tsconfig.type-tests.json
+++ b/packages/react-sdk/tsconfig.type-tests.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noEmit": true,
+    "paths": {
+      "@reflag/react-sdk": ["./src/index.tsx"]
+    }
+  },
+  "include": ["src", "test/opt-in-types.tsx"]
+}

--- a/packages/vue-sdk/README.md
+++ b/packages/vue-sdk/README.md
@@ -259,7 +259,7 @@ You'll typically generate the `bootstrappedFlags` object on your server using th
 
 If you want live flag updates to continue working after bootstrapping, use a recent `@reflag/node-sdk` so `getFlagsForBootstrap()` includes `flagStateVersion`.
 
-If bootstrap data omits opt-in metadata, `useOptInFlags()` triggers one flags refresh and reports `isLoading: true` until it settles. No request is made unless the composable is used.
+With `ReflagBootstrappedProvider`, `useOptInFlags()` triggers one flags refresh and reports `isLoading: true` until it settles. No refresh occurs unless the composable is used.
 
 Here's an example using the Node.js SDK:
 
@@ -426,7 +426,7 @@ User and company opt-ins are managed independently. Setting `optedIn` to `false`
 
 `setOptIn` returns a promise so you can wait for the new membership state to be synchronized. It resolves after the latest flag state has been applied, the requested membership change has been confirmed, and components using `useOptInFlags()` have been notified. Vue schedules the resulting render normally, so it may not yet be committed when the promise resolves.
 
-`useOptInFlags()` returns `{ flags, isLoading }`, where both values are computed refs. `isLoading` is only `true` when a bootstrapped payload does not contain browser opt-in metadata: the composable automatically requests it once, reports loading while that on-demand request is pending, and updates after the evaluated flags arrive. It returns to `false` after either success or failure. Bootstrapped payloads that already contain complete opt-in metadata report `false` immediately.
+`useOptInFlags()` returns `{ flags, isLoading }`, where both values are computed refs. With `ReflagBootstrappedProvider`, the composable fetches opt-in metadata on first use and reports `isLoading: true` until the flags refresh succeeds or fails.
 
 With a regular `ReflagProvider`, opt-in metadata arrives as part of the normal initial flags request, so `useOptInFlags().isLoading` remains `false`. Use the general `useIsLoading()` composable or the provider's loading slot for that initial loading state.
 

--- a/packages/vue-sdk/README.md
+++ b/packages/vue-sdk/README.md
@@ -259,7 +259,7 @@ You'll typically generate the `bootstrappedFlags` object on your server using th
 
 If you want live flag updates to continue working after bootstrapping, use a recent `@reflag/node-sdk` so `getFlagsForBootstrap()` includes `flagStateVersion`.
 
-The bootstrap payload is used synchronously for SSR and the initial client render. If `useOptInFlags()` is used and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. Applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use.
+The bootstrap payload is used synchronously for SSR and the initial client render. If `useOptInFlags()` is used and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. During that refresh, `useOptInFlags()` reports `isLoading: true`. Applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use and the loading state returns to `false`.
 
 Here's an example using the Node.js SDK:
 
@@ -401,18 +401,22 @@ Use these composables to build an end-user opt-in UI for flags where opt-in is e
 <script setup lang="ts">
 import { useOptInFlags, useSetOptIn } from "@reflag/vue-sdk";
 
-const optInFlags = useOptInFlags();
+const { flags: optInFlags, isLoading } = useOptInFlags();
 const setOptIn = useSetOptIn();
 </script>
 
 <template>
-  <button
-    v-for="flag in optInFlags"
-    :key="flag.key"
-    @click="setOptIn(flag.key, { optedIn: !flag.userOptedIn })"
-  >
-    {{ flag.userOptedIn ? "Cancel opt-in" : `Try ${flag.name}` }}
-  </button>
+  <p v-if="isLoading">Loading opt-in flags...</p>
+  <p v-else-if="optInFlags.length === 0">No opt-in flags are available.</p>
+  <template v-else>
+    <button
+      v-for="flag in optInFlags"
+      :key="flag.key"
+      @click="setOptIn(flag.key, { optedIn: !flag.userOptedIn })"
+    >
+      {{ flag.userOptedIn ? "Cancel opt-in" : `Try ${flag.name}` }}
+    </button>
+  </template>
 </template>
 ```
 
@@ -422,7 +426,9 @@ User and company opt-ins are managed independently. Setting `optedIn` to `false`
 
 `setOptIn` returns a promise so you can wait for the new membership state to be synchronized. It resolves after the latest flag state has been applied, the requested membership change has been confirmed, and components using `useOptInFlags()` have been notified. Vue schedules the resulting render normally, so it may not yet be committed when the promise resolves.
 
-When a bootstrapped payload does not contain browser opt-in metadata, `useOptInFlags()` automatically requests it once and updates after the evaluated flags arrive.
+`useOptInFlags()` returns `{ flags, isLoading }`, where both values are computed refs. `isLoading` is only `true` when a bootstrapped payload does not contain browser opt-in metadata: the composable automatically requests it once, reports loading while that on-demand request is pending, and updates after the evaluated flags arrive. It returns to `false` after either success or failure. Bootstrapped payloads that already contain complete opt-in metadata report `false` immediately.
+
+With a regular `ReflagProvider`, opt-in metadata arrives as part of the normal initial flags request, so `useOptInFlags().isLoading` remains `false`. Use the general `useIsLoading()` composable or the provider's loading slot for that initial loading state.
 
 ### `useTrack()`
 

--- a/packages/vue-sdk/README.md
+++ b/packages/vue-sdk/README.md
@@ -259,7 +259,7 @@ You'll typically generate the `bootstrappedFlags` object on your server using th
 
 If you want live flag updates to continue working after bootstrapping, use a recent `@reflag/node-sdk` so `getFlagsForBootstrap()` includes `flagStateVersion`.
 
-The bootstrap payload is used synchronously for SSR and the initial client render. If `useOptInFlags()` is used and the bootstrap payload does not include browser opt-in metadata, the browser SDK performs one evaluated-flags refresh on demand. During that refresh, `useOptInFlags()` reports `isLoading: true`. Applications that do not use opt-in data do not make this request. If the refresh fails, the bootstrapped flags remain in use and the loading state returns to `false`.
+If bootstrap data omits opt-in metadata, `useOptInFlags()` triggers one flags refresh and reports `isLoading: true` until it settles. No request is made unless the composable is used.
 
 Here's an example using the Node.js SDK:
 

--- a/packages/vue-sdk/package.json
+++ b/packages/vue-sdk/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --project tsconfig.build.json && vite build",
-    "test": "vitest run",
+    "test": "yarn test:types && vitest run",
+    "test:types": "tsc --project tsconfig.type-tests.json",
     "test:watch": "vitest",
     "test:ci": "yarn test --reporter=default --reporter=junit --outputFile=junit.xml",
     "coverage": "yarn test --coverage",

--- a/packages/vue-sdk/src/hooks.ts
+++ b/packages/vue-sdk/src/hooks.ts
@@ -127,9 +127,9 @@ export function useFlag<TKey extends FlagKey>(key: TKey): TypedFlags[TKey] {
  * Vue composable for getting opt-in-enabled flags and their loading state for
  * the current context.
  *
- * The loading state is only used with `ReflagBootstrappedProvider` when the
- * bootstrap payload does not contain browser opt-in metadata and it is fetched
- * on demand. Regular providers load opt-in metadata with the initial flags.
+ * The loading state is only used with `ReflagBootstrappedProvider` while
+ * opt-in metadata is fetched on demand. Regular providers load opt-in metadata
+ * with the initial flags.
  */
 export function useOptInFlags(): UseOptInFlagsResult {
   const client = useClient();

--- a/packages/vue-sdk/src/hooks.ts
+++ b/packages/vue-sdk/src/hooks.ts
@@ -10,7 +10,6 @@ import {
 import {
   HookArgs,
   InitOptions,
-  OptInFlag,
   ReflagClient,
   RequestFeedbackData,
   SetOptInOptions,
@@ -19,9 +18,11 @@ import {
 
 import {
   FlagKey,
+  OptInFlag,
   ProviderContextType,
   RequestFlagFeedbackOptions,
   TypedFlags,
+  UseOptInFlagsResult,
 } from "./types";
 import { SDK_VERSION } from "./version";
 
@@ -123,23 +124,38 @@ export function useFlag<TKey extends FlagKey>(key: TKey): TypedFlags[TKey] {
 }
 
 /**
- * Vue composable for getting opt-in-enabled flags for the current context.
+ * Vue composable for getting opt-in-enabled flags and their loading state for
+ * the current context.
+ *
+ * The loading state is only used with `ReflagBootstrappedProvider` when the
+ * bootstrap payload does not contain browser opt-in metadata and it is fetched
+ * on demand. Regular providers load opt-in metadata with the initial flags.
  */
-export function useOptInFlags() {
+export function useOptInFlags(): UseOptInFlagsResult {
   const client = useClient();
-  const optInFlags = ref<OptInFlag[]>(client.getOptInFlags());
+  const isBootstrapped = client.getConfig().bootstrapped;
+  const optInFlags = ref<OptInFlag[]>(client.getOptInFlags() as OptInFlag[]);
+  const isOptInFlagsLoading = ref(client.getIsLoadingOptInFlags());
 
   const updateOptInFlags = () => {
-    optInFlags.value = client.getOptInFlags();
+    optInFlags.value = client.getOptInFlags() as OptInFlag[];
   };
+  const updateIsLoading = (isLoading = client.getIsLoadingOptInFlags()) => {
+    isOptInFlagsLoading.value = isLoading;
+  };
+
+  useOnEvent("flagsUpdated", updateOptInFlags, client);
+  useOnEvent("optInFlagsLoadingUpdated", updateIsLoading, client);
 
   onMounted(() => {
     updateOptInFlags();
+    updateIsLoading();
   });
 
-  useOnEvent("flagsUpdated", updateOptInFlags, client);
-
-  return computed(() => optInFlags.value);
+  return {
+    flags: computed(() => optInFlags.value),
+    isLoading: computed(() => isBootstrapped && isOptInFlagsLoading.value),
+  };
 }
 
 /**

--- a/packages/vue-sdk/src/index.ts
+++ b/packages/vue-sdk/src/index.ts
@@ -24,6 +24,7 @@ export type {
   Flag,
   Flags,
   FlagType,
+  OptInFlag,
   ReflagBaseProps,
   ReflagBootstrappedProps,
   ReflagClientProviderProps,
@@ -31,11 +32,11 @@ export type {
   ReflagProps,
   RequestFlagFeedbackOptions,
   TypedFlags,
+  UseOptInFlagsResult,
 } from "./types";
 export type {
   CheckEvent,
   CompanyContext,
-  OptInFlag,
   SetOptInOptions,
   TrackEvent,
   UserContext,

--- a/packages/vue-sdk/src/index.ts
+++ b/packages/vue-sdk/src/index.ts
@@ -22,6 +22,7 @@ export type {
   BootstrappedFlags,
   EmptyFlagRemoteConfig,
   Flag,
+  FlagKey,
   Flags,
   FlagType,
   OptInFlag,

--- a/packages/vue-sdk/src/types.ts
+++ b/packages/vue-sdk/src/types.ts
@@ -163,8 +163,8 @@ export type ReflagProps = ReflagInitOptionsBase &
 export type ReflagBootstrappedProps = ReflagInitOptionsBase &
   ReflagBaseProps & {
     /**
-     * Pre-fetched flags used for the initial render. If opt-in flags are requested and
-     * browser opt-in metadata is missing, the browser client refreshes them on demand.
+     * Pre-fetched flags used for the initial render. The browser client fetches opt-in
+     * metadata on demand when opt-in flags are requested.
      */
     flags: BootstrappedFlags;
   };

--- a/packages/vue-sdk/src/types.ts
+++ b/packages/vue-sdk/src/types.ts
@@ -1,10 +1,11 @@
-import type { Ref } from "vue";
+import type { ComputedRef, Ref } from "vue";
 
 import type {
   BootstrappedState as BrowserBootstrappedState,
   CompanyContext,
   InitOptions,
   Logger,
+  OptInFlag as BrowserOptInFlag,
   RawFlags,
   ReflagClient,
   ReflagContext,
@@ -50,6 +51,15 @@ export type TypedFlags = keyof Flags extends never
     };
 
 export type FlagKey = keyof TypedFlags;
+
+export type OptInFlag = Omit<BrowserOptInFlag, "key"> & {
+  key: FlagKey;
+};
+
+export type UseOptInFlagsResult = {
+  flags: ComputedRef<OptInFlag[]>;
+  isLoading: ComputedRef<boolean>;
+};
 
 export interface ProviderContextType {
   client: ReflagClient;

--- a/packages/vue-sdk/test/opt-in-types.ts
+++ b/packages/vue-sdk/test/opt-in-types.ts
@@ -1,0 +1,23 @@
+import { useOptInFlags, useSetOptIn } from "@reflag/vue-sdk";
+
+declare module "@reflag/vue-sdk" {
+  interface Flags {
+    "generated-opt-in-flag": {};
+  }
+}
+
+export function GeneratedOptInTypes() {
+  const { flags, isLoading } = useOptInFlags();
+  const setOptIn = useSetOptIn();
+
+  for (const flag of flags.value) {
+    void setOptIn(flag.key, { optedIn: !flag.userOptedIn });
+  }
+
+  const loading: boolean = isLoading.value;
+
+  // @ts-expect-error generated flag types still reject unknown literal keys
+  void setOptIn("unknown-flag", { optedIn: true });
+
+  return loading;
+}

--- a/packages/vue-sdk/test/usage.test.ts
+++ b/packages/vue-sdk/test/usage.test.ts
@@ -27,6 +27,9 @@ beforeAll(() => {
   });
   vi.spyOn(ReflagClient.prototype, "getFlags").mockReturnValue({});
   vi.spyOn(ReflagClient.prototype, "getOptInFlags").mockReturnValue([]);
+  vi.spyOn(ReflagClient.prototype, "getIsLoadingOptInFlags").mockReturnValue(
+    false,
+  );
   vi.spyOn(ReflagClient.prototype, "setOptIn").mockResolvedValue(undefined);
   vi.spyOn(ReflagClient.prototype, "on").mockReturnValue(() => {
     // cleanup function
@@ -38,6 +41,13 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(ReflagClient.prototype.getOptInFlags).mockReturnValue([]);
+  vi.mocked(ReflagClient.prototype.getIsLoadingOptInFlags).mockReturnValue(
+    false,
+  );
+  vi.mocked(ReflagClient.prototype.on).mockReturnValue(() => {
+    // cleanup function
+  });
 });
 
 function getProvider() {
@@ -100,11 +110,14 @@ describe("ReflagProvider", () => {
       },
     ];
     vi.mocked(ReflagClient.prototype.getOptInFlags).mockReturnValue(optInFlags);
+    vi.mocked(ReflagClient.prototype.getIsLoadingOptInFlags).mockReturnValue(
+      true,
+    );
 
     const Child = defineComponent({
       setup() {
-        const flags = useOptInFlags();
-        return { flags };
+        const { flags, isLoading } = useOptInFlags();
+        return { flags, isLoading };
       },
       template: "<div></div>",
     });
@@ -118,10 +131,65 @@ describe("ReflagProvider", () => {
 
     await nextTick();
     expect(wrapper.findComponent(Child).vm.flags).toEqual(optInFlags);
+    expect(wrapper.findComponent(Child).vm.isLoading).toBe(false);
     expect(ReflagClient.prototype.on).toHaveBeenCalledWith(
       "flagsUpdated",
       expect.any(Function),
     );
+    expect(ReflagClient.prototype.on).toHaveBeenCalledWith(
+      "optInFlagsLoadingUpdated",
+      expect.any(Function),
+    );
+  });
+
+  test("useOptInFlags updates loading for missing bootstrapped metadata", async () => {
+    let loadingHandler: ((isLoading: boolean) => void) | undefined;
+    vi.mocked(ReflagClient.prototype.getIsLoadingOptInFlags).mockReturnValue(
+      true,
+    );
+    vi.mocked(ReflagClient.prototype.on).mockImplementation(
+      (event, handler) => {
+        if (event === "optInFlagsLoadingUpdated") {
+          loadingHandler = handler as (isLoading: boolean) => void;
+        }
+        return () => {
+          // cleanup function
+        };
+      },
+    );
+
+    const Child = defineComponent({
+      setup() {
+        const { flags, isLoading } = useOptInFlags();
+        return { flags, isLoading };
+      },
+      template: "<div></div>",
+    });
+
+    const wrapper = mount(ReflagBootstrappedProvider, {
+      props: {
+        publishableKey: "key-loading-opt-in-flags",
+        flags: {
+          context: { user: { id: "user-1" } },
+          flags: {
+            optInFlag: {
+              key: "optInFlag",
+              isEnabled: false,
+              targetingVersion: 1,
+            },
+          },
+        },
+      },
+      slots: { default: () => h(Child) },
+    });
+
+    await nextTick();
+    expect(wrapper.findComponent(Child).vm.isLoading).toBe(true);
+
+    loadingHandler?.(false);
+    await nextTick();
+
+    expect(wrapper.findComponent(Child).vm.isLoading).toBe(false);
   });
 
   test("useSetOptIn delegates to the browser client", async () => {

--- a/packages/vue-sdk/tsconfig.type-tests.json
+++ b/packages/vue-sdk/tsconfig.type-tests.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noEmit": true,
+    "paths": {
+      "@reflag/vue-sdk": ["./src/index.ts"]
+    }
+  },
+  "include": ["src", "test/opt-in-types.ts"]
+}


### PR DESCRIPTION
## Summary

- narrow React and Vue `OptInFlag.key` to each SDK's generated `FlagKey`, so values returned by `useOptInFlags()` pass directly to `useSetOptIn()`
- expose browser opt-in loading through `getIsLoadingOptInFlags()` and the `optInFlagsLoadingUpdated` event
- return `{ flags, isLoading }` from the React and Vue `useOptInFlags()` APIs
- report opt-in `isLoading` only while bootstrapped providers fetch opt-in metadata on first use; regular providers continue to use `useIsLoading()` for their normal initial flags request
- support provider-level and per-hook Suspense in React while regular flags or required bootstrapped opt-in metadata load
- keep loading tied to the latest context/bootstrap generation so stale or concurrent refreshes cannot clear newer loading state
- document manual spinner/empty-state handling, the bootstrapping-specific loading case, and React Suspense behavior

## API

React:

```tsx
const { flags, isLoading } = useOptInFlags();
```

Vue (both values are computed refs and are automatically unwrapped in templates):

```ts
const { flags, isLoading } = useOptInFlags();
```

With a bootstrapped provider, `isLoading` is true while fetching opt-in metadata on first use. With a regular provider, opt-in metadata arrives with the normal flags response and `useIsLoading()` covers that initial request.

Unaugmented SDK consumers still get string flag keys; generated/augmented consumers get their existing `FlagKey` union without weakening other typed flag APIs.

## Tests

Added coverage for:

- generated React and Vue `Flags` type augmentation and direct `flag.key` usage with `useSetOptIn()`
- regular-provider loading versus bootstrapped opt-in metadata loading
- successful and failed bootstrapped metadata refreshes
- context races, newly applied bootstrap state, stale refreshes, and offline mode
- React and Vue reactive rerenders
- React Suspense with regular providers and missing bootstrap metadata
- React Suspense failure recovery and per-hook opt-out

Commands run:

- `yarn workspace @reflag/browser-sdk test`
- `yarn workspace @reflag/react-sdk test`
- `yarn workspace @reflag/react-sdk test:types`
- `yarn workspace @reflag/vue-sdk test`
- `yarn workspace @reflag/vue-sdk test:types`
- `yarn lint`
- `yarn fmt`
- `yarn workspace @reflag/browser-sdk build`
- `yarn workspace @reflag/react-sdk build`
- `yarn workspace @reflag/react-native-sdk build`
- `yarn workspace @reflag/vue-sdk build`
- `yarn changeset status`

